### PR TITLE
Add call-to-action buttons to English hero section

### DIFF
--- a/english/english.html
+++ b/english/english.html
@@ -44,6 +44,10 @@
       <img class="profile-image" src="./english/Me&wify.png" alt="Carlos Ortega">
       <h1 class="display-4">Carlos Ortega González</h1>
       <p class="lead">Python Developer | Data Analyst | Problem-Solver</p>
+      <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
+        <a class="btn btn-primary btn-lg mb-3 mb-sm-0 mr-sm-3" href="https://example.com/carlos-ortega-resume.pdf" target="_blank" rel="noopener">Download Résumé</a>
+        <a class="btn btn-outline-light btn-lg" href="#contact">Contact Me</a>
+      </div>
     </div>
   </header>
 

--- a/english/english/style.css
+++ b/english/english/style.css
@@ -22,6 +22,38 @@ body {
     padding: 80px 0;
   }
 
+.hero-cta {
+  margin-top: 24px;
+}
+
+.hero-cta .btn {
+  font-weight: 600;
+  padding: 12px 28px;
+  border-radius: 50px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-cta .btn-primary {
+  background-color: #007bff;
+  border-color: #007bff;
+}
+
+.hero-cta .btn-primary:hover,
+.hero-cta .btn-outline-light:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+}
+
+.hero-cta .btn-outline-light {
+  color: #fff;
+  border-color: #f8f9fa;
+}
+
+.hero-cta .btn-outline-light:hover {
+  background-color: #f8f9fa;
+  color: #000;
+}
+
   .profile-image {
     width: 360px;
     height: 360px;


### PR DESCRIPTION
## Summary
- add download resume and contact hero buttons to the English landing page
- style the new hero call-to-action buttons to complement the dark theme and remain responsive

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d761d64804832f90ca079aacf39682