### PR TITLE
Create synthwave landing hero

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -1,0 +1,305 @@
+:root {
+  --bg-color: #04010f;
+  --text-color: #eef6ff;
+  --grid-color: rgba(0, 255, 213, 0.3);
+  --card-background: rgba(6, 12, 24, 0.85);
+  --card-border: rgba(0, 255, 213, 0.4);
+  --accent-hue: 200;
+  --accent-color: hsl(var(--hue-shift, var(--accent-hue)) 85% 60%);
+  --glow-color: hsla(var(--hue-shift, var(--accent-hue)) 90% 60% / 0.55);
+  --scanline-color: rgba(255, 255, 255, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Orbitron', 'Share Tech Mono', 'Courier New', monospace;
+  background: var(--bg-color);
+  color: var(--text-color);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    0deg,
+    var(--scanline-color) 0,
+    var(--scanline-color) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  opacity: 0.2;
+  mix-blend-mode: screen;
+  z-index: 5;
+}
+
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2rem, 6vw, 7rem);
+  text-align: center;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 120% at 50% 0%, rgba(255, 0, 128, 0.35), transparent),
+    radial-gradient(140% 140% at 50% 110%, rgba(0, 180, 255, 0.28), transparent),
+    var(--bg-color);
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: -25% -50% -70% -50%;
+  background-image:
+    linear-gradient(to right, var(--grid-color) 1px, transparent 1px),
+    linear-gradient(to top, var(--grid-color) 1px, transparent 1px);
+  background-size: 140px 140px;
+  transform: perspective(800px) rotateX(72deg);
+  transform-origin: top center;
+  opacity: 0.6;
+  filter: drop-shadow(0 0 12px rgba(0, 255, 213, 0.4));
+  z-index: 0;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 30%, hsla(var(--hue-shift, var(--accent-hue)) 90% 65% / 0.4), transparent 60%),
+    radial-gradient(circle at 80% 60%, hsla(calc(var(--hue-shift, var(--accent-hue)) + 40) 95% 65% / 0.35), transparent 65%),
+    radial-gradient(circle at 20% 80%, hsla(calc(var(--hue-shift, var(--accent-hue)) + 120) 90% 60% / 0.25), transparent 70%);
+  mix-blend-mode: screen;
+  opacity: 0.75;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 2;
+  max-width: 1024px;
+  width: min(100%, 1040px);
+}
+
+.hero-header {
+  margin-bottom: clamp(2rem, 4vw, 3.5rem);
+}
+
+.hero-eyebrow {
+  letter-spacing: 0.35em;
+  font-size: clamp(0.65rem, 1.4vw, 0.9rem);
+  text-transform: uppercase;
+  color: rgba(238, 246, 255, 0.66);
+  margin: 0 0 1rem;
+}
+
+.hero-header h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.2rem, 6vw, 4.5rem);
+  line-height: 1.1;
+  text-shadow: 0 0 20px rgba(0, 255, 213, 0.2), 0 0 40px rgba(255, 0, 128, 0.2);
+}
+
+.hero-subhead {
+  margin: 0;
+  font-size: clamp(1rem, 2vw, 1.3rem);
+  color: rgba(238, 246, 255, 0.75);
+}
+
+.lang-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  justify-items: center;
+}
+
+.lang-card {
+  position: relative;
+  width: min(100%, 400px);
+  padding: clamp(2rem, 4vw, 2.75rem);
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  border-radius: 22px;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.05) inset,
+    0 25px 55px rgba(0, 0, 0, 0.6),
+    0 0 35px rgba(0, 255, 213, 0.15);
+  overflow: hidden;
+  transition: transform 350ms ease, box-shadow 350ms ease;
+  backdrop-filter: blur(6px);
+}
+
+.lang-card__glow {
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(circle at center, var(--glow-color), transparent 65%);
+  opacity: 0;
+  transition: opacity 350ms ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.lang-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.lang-card__flag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid rgba(238, 246, 255, 0.35);
+  background: rgba(238, 246, 255, 0.06);
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+}
+
+.lang-card h2 {
+  font-size: clamp(1.7rem, 3vw, 2.2rem);
+  margin: 0;
+}
+
+.lang-card__copy {
+  font-family: 'Share Tech Mono', 'Courier New', monospace;
+  font-size: clamp(0.95rem, 1.8vw, 1.1rem);
+  line-height: 1.6;
+  color: rgba(238, 246, 255, 0.82);
+  margin: 0 0 1.8rem;
+  position: relative;
+  z-index: 1;
+}
+
+.lang-card__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(238, 246, 255, 0.5);
+  text-decoration: none;
+  color: var(--text-color);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: background 300ms ease, box-shadow 300ms ease, color 300ms ease;
+  position: relative;
+  z-index: 1;
+  background: rgba(238, 246, 255, 0.08);
+  box-shadow: 0 0 15px rgba(255, 255, 255, 0.18);
+}
+
+.lang-card__cta span {
+  display: inline-block;
+}
+
+.cta-icon {
+  width: 1.4rem;
+  height: 1.4rem;
+}
+
+.lang-card:hover,
+.lang-card:focus-within {
+  transform: translateY(-8px) scale(1.02);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.09) inset,
+    0 30px 65px rgba(0, 0, 0, 0.65),
+    0 0 45px rgba(0, 255, 213, 0.22);
+}
+
+.lang-card:hover .lang-card__glow,
+.lang-card:focus-within .lang-card__glow {
+  opacity: 0.8;
+}
+
+.lang-card__cta:hover,
+.lang-card__cta:focus-visible {
+  background: var(--accent-color);
+  color: #02040a;
+  box-shadow: 0 0 25px var(--accent-color);
+}
+
+.particle-field {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.particle {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+  opacity: 0.7;
+  animation: float 8s linear infinite;
+}
+
+@keyframes float {
+  from {
+    transform: translate3d(var(--x-offset), 100vh, 0);
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.8;
+  }
+  to {
+    transform: translate3d(var(--x-offset), -10vh, 0);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: clamp(2rem, 6vw, 3rem) clamp(1.5rem, 5vw, 2.5rem);
+  }
+
+  .hero-header h1 {
+    font-size: clamp(2rem, 7vw, 3.3rem);
+  }
+
+  .lang-card {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  body::after {
+    opacity: 0.12;
+  }
+
+  .lang-card,
+  .lang-card__glow,
+  .lang-card__cta {
+    transition: none;
+  }
+}

--- a/assets/js/landing.js
+++ b/assets/js/landing.js
@@ -1,0 +1,82 @@
+const root = document.documentElement;
+const particleField = document.querySelector('.particle-field');
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+let animationFrameId = null;
+let particlesActive = false;
+
+const createParticles = () => {
+  if (!particleField || particlesActive) {
+    return;
+  }
+
+  const particleTotal = Math.min(32, Math.max(18, Math.round(window.innerWidth / 45)));
+
+  for (let i = 0; i < particleTotal; i += 1) {
+    const particle = document.createElement('span');
+    particle.className = 'particle';
+    particle.style.left = `${Math.random() * 100}%`;
+    particle.style.setProperty('--x-offset', `${Math.random() * 40 - 20}vw`);
+    particle.style.animationDuration = `${6 + Math.random() * 6}s`;
+    particle.style.animationDelay = `${-Math.random() * 8}s`;
+    particleField.appendChild(particle);
+  }
+
+  particlesActive = true;
+};
+
+const clearParticles = () => {
+  if (!particleField) {
+    return;
+  }
+  particleField.innerHTML = '';
+  particlesActive = false;
+};
+
+const animateHueShift = () => {
+  let hue = Number.parseFloat(getComputedStyle(root).getPropertyValue('--hue-shift')) || 200;
+
+  const tick = () => {
+    hue = (hue + 0.35) % 360;
+    root.style.setProperty('--hue-shift', hue.toFixed(2));
+    animationFrameId = requestAnimationFrame(tick);
+  };
+
+  animationFrameId = requestAnimationFrame(tick);
+};
+
+const stopHueShift = () => {
+  if (animationFrameId) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+  root.style.removeProperty('--hue-shift');
+};
+
+const enableDynamicEffects = () => {
+  createParticles();
+  animateHueShift();
+};
+
+const disableDynamicEffects = () => {
+  stopHueShift();
+  clearParticles();
+};
+
+const updateEffectsForMotionPreference = () => {
+  if (prefersReducedMotion.matches) {
+    disableDynamicEffects();
+  } else {
+    enableDynamicEffects();
+  }
+};
+
+updateEffectsForMotionPreference();
+
+prefersReducedMotion.addEventListener('change', updateEffectsForMotionPreference);
+
+window.addEventListener('resize', () => {
+  if (!prefersReducedMotion.matches && particlesActive) {
+    clearParticles();
+    createParticles();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -3,72 +3,53 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bienvenido / Welcome</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    /* Global Styles */
-    body {
-      font-family: Arial, sans-serif;
-    }
-
-    /* Container Styles */
-    .container {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      padding: 20px;
-      text-align: center;
-      height: 100vh;
-    }
-
-    .container-left, .container-right {
-      width: 100%;
-      max-width: 50%;
-      padding: 20px;
-      box-sizing: border-box;
-      margin-top: 10px;
-    }
-
-    /* Button Styles */
-    .btn-welcome {
-      display: inline-block;
-      padding: 10px 20px;
-      background-color: #333;
-      color: #fff;
-      text-decoration: none;
-      font-size: 18px;
-      font-weight: bold;
-      border-radius: 5px;
-      margin: 10px;
-    }
-
-    .btn-welcome:hover {
-      background-color: #555;
-    }
-
-    /* Media Query for Larger Screens */
-    @media (min-width: 768px) {
-      .container {
-        flex-direction: row;
-        justify-content: center;
-        align-items: flex-start;
-      }
-    }
-  </style>
+  <title>Welcome / Bienvenido</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/landing.css">
 </head>
 <body>
-  <div class="container">
-    <div class="container-left">
-      <h1>Bienvenido a mi portafolio</h1>
-      <p>...donde la creatividad se une con el propósito.</p>
-      <a href="index-spa.html" class="btn-welcome">Español</a>
+  <main class="hero" aria-labelledby="landing-title">
+    <div class="hero-content">
+      <header class="hero-header">
+        <p class="hero-eyebrow">Select your access channel</p>
+        <h1 id="landing-title">Welcome to the Cortega Mainframe</h1>
+        <p class="hero-subhead">Choose your preferred language to enter this synthwave-powered portfolio experience.</p>
+      </header>
+      <div class="lang-grid">
+        <section class="lang-card" aria-labelledby="english-card">
+          <div class="lang-card__glow" aria-hidden="true"></div>
+          <header class="lang-card__header">
+            <span class="lang-card__flag" aria-hidden="true">EN</span>
+            <h2 id="english-card">English</h2>
+          </header>
+          <p class="lang-card__copy">Dive into the English version of the site to explore projects, skills, and the story behind the work.</p>
+          <a class="lang-card__cta" href="./english/english.html">
+            <span>Enter the portal</span>
+            <svg class="cta-icon" viewBox="0 0 24 24" role="presentation" focusable="false" aria-hidden="true">
+              <path d="M5 12h12m0 0-4-4m4 4-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </a>
+        </section>
+        <section class="lang-card" aria-labelledby="spanish-card">
+          <div class="lang-card__glow" aria-hidden="true"></div>
+          <header class="lang-card__header">
+            <span class="lang-card__flag" aria-hidden="true">ES</span>
+            <h2 id="spanish-card">Español</h2>
+          </header>
+          <p class="lang-card__copy">Ingresa a la versión en español para conocer los proyectos, habilidades y la historia detrás del trabajo.</p>
+          <a class="lang-card__cta" href="index-spa.html">
+            <span>Ingresar al portal</span>
+            <svg class="cta-icon" viewBox="0 0 24 24" role="presentation" focusable="false" aria-hidden="true">
+              <path d="M5 12h12m0 0-4-4m4 4-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </a>
+        </section>
+      </div>
     </div>
-
-    <div class="container-right">
-      <h1>Welcome to my portfolio</h1>
-      <p>...where creativity meets purpose.</p>
-      <a href="./english/english.html" class="btn-welcome">English</a>
-    </div>
-  </div>
+    <div class="particle-field" aria-hidden="true"></div>
+  </main>
+  <script src="assets/js/landing.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the landing page markup with a full-height neon hero featuring bilingual cards and icon CTAs
- extract inline styling into a dedicated landing stylesheet with synthwave typography, glowing grid, and responsive tweaks
- add a lightweight animation script that drives hue shifts and floating particles with respect for reduced-motion settings

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d768f30708832f8e7ebdd98b318411