### PR TITLE
Update portfolio CTAs and highlight File Extractor Pro

### DIFF
--- a/english/english.html
+++ b/english/english.html
@@ -49,8 +49,8 @@
         <li>Senior Python developer guiding cross-functional teams from concept to deployment</li>
       </ul>
       <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
-        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="https://example.com/carlos-ortega-resume.pdf" target="_blank" rel="noopener">Download Résumé</a>
-        <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26/discovery-call" target="_blank" rel="noopener">Book a Discovery Call</a>
+        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="mailto:carlosortega77@gmail.com?subject=Resume%20Request" rel="noopener">Request Résumé</a>
+        <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Book a Discovery Call</a>
       </div>
     </div>
   </header>
@@ -215,9 +215,9 @@
                 <li><strong>Impact:</strong> Accelerated compliance reviews by surfacing key phrases 60% faster for the audit team.</li>
               </ul>
               <div class="project-links">
-                <a href="https://github.com/cortega26/PDF-Text-Analizer#usage" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Usage Docs</a>
+                <a href="https://github.com/cortega26/PDF-Text-Analyzer#usage" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Usage Docs</a>
               </div>
-              <a href="https://github.com/cortega26/PDF-Text-Analizer" class="btn btn-primary">View Project on GitHub</a>
+              <a href="https://github.com/cortega26/PDF-Text-Analyzer" class="btn btn-primary">View Project on GitHub</a>
             </div>
           </div>
         </div>
@@ -251,23 +251,23 @@
         <div class="col-md-6">
           <div class="card mb-4 custom-card">
             <div class="card-body text-center">
-              <h4 class="card-title">Django Vehicle Registry</h4>
-              <p class="card-text">Django project for registering and visualizing vehicle information. Allows adding, storing, and viewing details of various vehicles.</p>
+              <h4 class="card-title">File Extractor Pro</h4>
+              <p class="card-text">Desktop automation suite that inventories folders, applies compliance filters, and ships tamper-evident extraction reports in minutes.</p>
               <div class="project-badges">
-                <span class="badge badge-tech">Django</span>
-                <span class="badge badge-tech">PostgreSQL</span>
-                <span class="badge badge-tech">Bootstrap</span>
+                <span class="badge badge-tech">Python</span>
+                <span class="badge badge-tech">Tkinter</span>
+                <span class="badge badge-tech">AsyncIO</span>
               </div>
               <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Led full-stack delivery, enforced role-based permissions, and implemented CI for automated deployments.</li>
-                <li><strong>Tech stack:</strong> Django, Celery, PostgreSQL, Redis cache, GitHub Actions.</li>
-                <li><strong>Data volume:</strong> Manages 45K vehicle records with nightly batch imports.</li>
-                <li><strong>Impact:</strong> Cut onboarding time for municipal clerks by 35% via self-service search and audit trails.</li>
+                <li><strong>Contribution:</strong> Engineered the asynchronous extraction engine, hardened structured logging, and delivered a Tkinter command center for non-technical reviewers.</li>
+                <li><strong>Tech stack:</strong> Python 3.9+, Tkinter, asyncio, aiofiles, RotatingFileHandler audit logs.</li>
+                <li><strong>Data volume:</strong> Streams metadata with background workers so large directory trees process without freezing the UI.</li>
+                <li><strong>Impact:</strong> Equipped compliance and security reviewers to export evidence packs on demand without manual file triage.</li>
               </ul>
               <div class="project-links">
-                <a href="https://github.com/cortega26/Django-Vehicle-Registry#deployment" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Deployment Notes</a>
+                <a href="https://github.com/cortega26/File-Extractor-Pro#features" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Feature Overview</a>
               </div>
-              <a href="https://cortega26.pythonanywhere.com/" class="btn btn-primary">View Live Project</a>
+              <a href="https://github.com/cortega26/File-Extractor-Pro" class="btn btn-primary">View Project on GitHub</a>
             </div>
           </div>
         </div>
@@ -285,9 +285,9 @@
           <div class="contact-summary h-100">
             <p>Let's build resilient data products together. Share a short brief or invite me to a discovery call—I'll respond with next steps and resources tailored to your roadmap.</p>
             <div class="contact-actions">
-              <a class="btn btn-cta contact-btn" href="https://example.com/carlos-ortega-resume.pdf" target="_blank" rel="noopener">Download Résumé</a>
+              <a class="btn btn-cta contact-btn" href="mailto:carlosortega77@gmail.com?subject=Resume%20Request" rel="noopener">Request Résumé</a>
               <a class="btn btn-outline-light contact-btn" href="https://www.linkedin.com/in/cortega26" target="_blank" rel="noopener">Connect on LinkedIn</a>
-              <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26/discovery-call" target="_blank" rel="noopener">Schedule via Calendly</a>
+              <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Schedule via Calendly</a>
             </div>
             <p class="contact-response">Preferred response window: within 48 business hours, with calls available Tuesday–Thursday, 9:00–15:00 CLT.</p>
             <p class="contact-response">Need a faster answer? Email me directly and I'll prioritize urgent production issues.</p>


### PR DESCRIPTION
## Summary
- retarget the hero and contact résumé CTAs to a mailto request and fix the Calendly link
- point the PDF to Text Analyzer buttons at the corrected GitHub repository slug
- swap the defunct Django Vehicle Registry card for File Extractor Pro with refreshed positioning

## Testing
- `npx linkinator english/english.html --silent` *(Udemy certificate links return 403 because they require a browser session)*

------
https://chatgpt.com/codex/tasks/task_e_68d76a2cc488832faf01777ffa38fe64