### PR TITLE
Create localized Spanish portfolio page

### DIFF
--- a/index-spa.html
+++ b/index-spa.html
@@ -1,14 +1,340 @@
 <!DOCTYPE html>
 <html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Portafolio</title>
-</head>
-<body>
-    <h1>Bienvenido a mi web</h1>
 
-    <a href="./edutecno/edu-index.html">Edutecno</a>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Portafolio de Carlos Ortega</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+  <link rel="stylesheet" href="./spanish/style.css">
+</head>
+
+<body>
+  <!-- Navbar -->
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container">
+      <a class="navbar-brand" href="#" id="pi" onclick="showPiMessage()">π</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-item">
+            <a class="nav-link" href="#about">Sobre mí</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#certifications">Certificaciones</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#portfolio">Portafolio</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#contact">Contacto</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Landing Section -->
+  <header class="landing" id="home">
+    <div class="container text-center">
+      <img class="profile-image" src="./english/english/Me&wify.png" alt="Carlos Ortega">
+      <h1 class="display-4">Carlos Ortega González</h1>
+      <ul class="hero-highlights">
+        <li>Socio estratégico de analítica para innovadores en fintech, ciberseguridad y sector público.</li>
+        <li>Generé ahorros de dos dígitos con paneles automatizados y pronósticos impulsados por machine learning.</li>
+        <li>Desarrollador senior de Python que guía equipos multifuncionales desde la idea hasta la puesta en producción.</li>
+      </ul>
+      <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
+        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="mailto:carlosortega77@gmail.com?subject=Solicitud%20de%20CV" rel="noopener">Solicitar CV</a>
+        <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar llamada de descubrimiento</a>
+      </div>
+    </div>
+  </header>
+
+  <!-- About Section -->
+  <section class="about" id="about">
+    <div class="container">
+      <h2 class="text-center">Sobre mí</h2><br>
+
+      <p class="about-intro">Ayudo a equipos de fintech y ciberseguridad a traducir datos complejos en productos seguros y escalables que llegan a producción a tiempo.</p>
+
+      <ul class="about-highlights">
+        <li>Automaticé flujos de reportes regulatorios que devuelven 420 horas de analistas por trimestre para enfocarse en la ejecución del roadmap.</li>
+        <li>Diseñé pipelines de analítica que consolidan más de 65 conjuntos de datos dispares para inteligencia de fraude y scoring de riesgo.</li>
+        <li>Lideré escuadras multifuncionales de 8 ingenieros y analistas para entregar insights basados en Python y SQL con 99% de cumplimiento SLA.</li>
+        <li>Contribuyente activo en Python Chile y meetups de seguridad fintech, compartiendo playbooks sobre automatización resiliente.</li>
+        <li>Comprometido con el aprendizaje continuo a través de Coursera, Udacity y experimentación práctica con herramientas emergentes de seguridad.</li>
+      </ul>
+    </div>
+  </section>
+
+
+  <!-- Certifications Section -->
+  <section class="certifications" id="certifications">
+    <div class="container">
+      <h2 class="text-center">Certificaciones</h2><br>
+      <!-- List of Certifications -->
+      <ul>
+        <li>
+          <strong><a href="https://www.udemy.com/certificate/UC-6516cd74-a25b-405d-962d-f3f6296db1c0/">Automate the boring stuff with Python Programming</a></strong>
+          Udemy | Emitido: diciembre 2022
+        </li>
+        <li>
+          <strong><a href="https://www.credly.com/badges/7b6d0fbb-81b4-4b90-a07a-ad49506619cc/linked_in_profile">Data Science Orientation</a></strong>
+          Coursera | Emitido: octubre 2022
+        </li>
+        <li>
+          <strong><a href="https://graduation.udacity.com/confirm/KVWVKZFW">AWS Machine Learning Foundations</a></strong>
+          Udacity | Emitido: septiembre 2022
+        </li>
+        <li>
+          <strong><a href="https://www.efset.org/cert/W91jYa">EF SET English Certificate</a></strong>
+          EF | Emitido: junio 2022
+        </li>
+        <li>
+          <strong><a href="https://www.credly.com/badges/bfe5a0e2-b688-4300-be52-97d4ca8d6f6e/public_url">Google Data Analytics</a></strong>
+          Coursera | Emitido: mayo 2022
+        </li>
+        <li>
+          <strong><a href="https://www.udemy.com/certificate/UC-0d585a57-068e-4d51-9360-48283b103059/?utm_campaign=email&utm_source=sendgrid.com&utm_medium=email">The Self-Taught Programmer</a></strong>
+          Udemy | Emitido: marzo 2022
+        </li>
+        <li>
+          <strong><a href="https://www.udemy.com/certificate/UC-333e6d66-a544-475f-8cf7-747487ad2bc0/">Business Intelligence Analyst</a></strong>
+          Udemy | Emitido: octubre 2021
+        </li>
+        <li>
+          <strong><a href="https://www.credly.com/badges/01c42a0d-8939-41e4-8d26-73a796a95594/public_url">SCRUM Foundation Professional</a></strong>
+          CertiProf | Emitido: noviembre 2020 (actualizado mayo 2023)
+        </li>
+        <li>
+          <strong><a href="https://www.credly.com/badges/6396404d-ef8e-4388-b3d2-4f858afea8f9">Cisco Certified Network Associate Routing and Switching (CCNA R&amp;S)</a></strong>
+          Cisco | Emitido: septiembre 2016
+        </li>
+      </ul>
+    </div>
+  </section>
+
+
+  <!-- Portfolio Section -->
+  <section class="portfolio" id="portfolio">
+    <div class="container">
+      <h2 class="text-center">Portafolio</h2><br>
+
+      <div class="row">
+        <!-- Project 1 Card -->
+        <div class="col-md-6">
+          <div class="card mb-4 custom-card">
+            <div class="card-body text-center">
+              <h4 class="card-title">Data Viz: Crecimiento PIB per cápita PPA</h4>
+              <p class="card-text">Bar Chart Race: crecimiento porcentual del PIB per cápita PPA (USD corrientes internacionales) desde 1990 en países de América.</p>
+              <div class="project-badges">
+                <span class="badge badge-tech">Python</span>
+                <span class="badge badge-tech">Flourish</span>
+                <span class="badge badge-tech">ETL</span>
+              </div>
+              <ul class="project-details text-left">
+                <li><strong>Aporte:</strong> Seleccioné datos del Banco Mundial, automaticé scripts de limpieza y produje visualizaciones animadas con narrativa.</li>
+                <li><strong>Stack:</strong> Pandas, plantillas de Flourish Studio, GitHub Actions para refresco programado.</li>
+                <li><strong>Volumen:</strong> 31 años × 22 países (~680 registros) actualizados trimestralmente.</li>
+                <li><strong>Impacto:</strong> Entregué insumos listos para sesiones ejecutivas, reduciendo en 3 horas la preparación manual de gráficos por actualización.</li>
+              </ul>
+              <a href="https://public.flourish.studio/visualisation/9177797/" class="btn btn-primary">Ver visualización</a>
+            </div>
+          </div>
+        </div>
+
+        <!-- Project 2 Card -->
+        <div class="col-md-6">
+          <div class="card mb-4 custom-card">
+            <div class="card-body text-center">
+              <h4 class="card-title">Data Viz: Inflación acumulada en países de la OCDE</h4>
+              <p class="card-text">Bar Chart Race: inflación acumulada en los países de la OCDE entre 1990 y 2020.</p>
+              <div class="project-badges">
+                <span class="badge badge-tech">Python</span>
+                <span class="badge badge-tech">Flourish</span>
+                <span class="badge badge-tech">OECD API</span>
+              </div>
+              <ul class="project-details text-left">
+                <li><strong>Aporte:</strong> Construí scripts de extracción con la API de la OCDE y unifiqué índices IPC para comparar países.</li>
+                <li><strong>Stack:</strong> Requests, Pandas, Flourish Studio, Airtable para flujo de anotaciones.</li>
+                <li><strong>Volumen:</strong> 30 años × 38 miembros de la OCDE (~1.1K registros).</li>
+                <li><strong>Impacto:</strong> Permití que analistas detectaran outliers de inflación en menos de 5 minutos, acelerando la producción del boletín.</li>
+              </ul>
+              <a href="https://public.flourish.studio/visualisation/9291169/" class="btn btn-primary">Ver visualización</a>
+            </div>
+          </div>
+        </div>
+
+        <!-- Project 3 Card -->
+        <div class="col-md-6">
+          <div class="card mb-4 custom-card">
+            <div class="card-body text-center">
+              <h4 class="card-title">Prize Scrapper para polla.cl</h4>
+              <p class="card-text">Script en Python que extrae información de premios del sitio de apuestas chileno polla.cl y actualiza una Google Sheet.</p>
+              <div class="project-badges">
+                <span class="badge badge-tech">Python</span>
+                <span class="badge badge-tech">BeautifulSoup</span>
+                <span class="badge badge-tech">Google Sheets API</span>
+              </div>
+              <ul class="project-details text-left">
+                <li><strong>Aporte:</strong> Investigué las tablas de premios, implementé scraping resiliente y orquesté actualizaciones diarias para los interesados.</li>
+                <li><strong>Stack:</strong> Requests, BeautifulSoup, gspread, contenedor Docker con cron.</li>
+                <li><strong>Volumen:</strong> Más de 80 sorteos capturados semanalmente con historial.</li>
+                <li><strong>Impacto:</strong> Automaticé la actualización semanal, reduciendo 4 horas de trabajo manual y eliminando errores de reporte.</li>
+              </ul>
+              <div class="project-links">
+                <a href="https://github.com/cortega26/polla#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">README del proyecto</a>
+              </div>
+              <a href="https://github.com/cortega26/polla" class="btn btn-primary">Ver proyecto en GitHub</a>
+            </div>
+          </div>
+        </div>
+
+        <!-- Project 4 Card -->
+        <div class="col-md-6">
+          <div class="card mb-4 custom-card">
+            <div class="card-body text-center">
+              <h4 class="card-title">PDF to Text Analyzer</h4>
+              <p class="card-text">Script en Python para descargar PDFs, convertirlos a texto y realizar análisis, incluyendo identificación de idioma y conteo de frecuencia.</p>
+              <div class="project-badges">
+                <span class="badge badge-tech">Python</span>
+                <span class="badge badge-tech">NLTK</span>
+                <span class="badge badge-tech">AWS S3</span>
+              </div>
+              <ul class="project-details text-left">
+                <li><strong>Aporte:</strong> Diseñé la canalización de ingesta, normalicé corpus multilingües y empaqueté utilidades reutilizables de línea de comandos.</li>
+                <li><strong>Stack:</strong> PyPDF2, langdetect, NLTK, AWS S3 para archivado, pruebas con GitHub Actions.</li>
+                <li><strong>Volumen:</strong> Procesa lotes de más de 500 PDFs (aprox. 1.2 GB) por ejecución.</li>
+                <li><strong>Impacto:</strong> Aceleré las revisiones de cumplimiento al resaltar frases clave 60% más rápido para el equipo de auditoría.</li>
+              </ul>
+              <div class="project-links">
+                <a href="https://github.com/cortega26/PDF-Text-Analyzer#usage" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Documentación de uso</a>
+              </div>
+              <a href="https://github.com/cortega26/PDF-Text-Analyzer" class="btn btn-primary">Ver proyecto en GitHub</a>
+            </div>
+          </div>
+        </div>
+
+        <!-- Project 5 Card -->
+        <div class="col-md-6">
+          <div class="card mb-4 custom-card">
+            <div class="card-body text-center">
+              <h4 class="card-title">Fast Search API</h4>
+              <p class="card-text">Implementación eficiente en FastAPI para buscar datos JSON usando filtros por nombre, apellido, RUT y edad.</p>
+              <div class="project-badges">
+                <span class="badge badge-tech">FastAPI</span>
+                <span class="badge badge-tech">Docker</span>
+                <span class="badge badge-tech">PostgreSQL</span>
+              </div>
+              <ul class="project-details text-left">
+                <li><strong>Aporte:</strong> Arquitecté endpoints asíncronos, indexé campos de búsqueda y añadí tableros de observabilidad.</li>
+                <li><strong>Stack:</strong> FastAPI, SQLAlchemy, PostgreSQL, Docker Compose, pytest.</li>
+                <li><strong>Volumen:</strong> Probado con 2,5 millones de registros con latencia &lt; 150 ms.</li>
+                <li><strong>Impacto:</strong> Entregué una experiencia de consulta 6× más rápida para equipos de soporte que validan fraudes.</li>
+              </ul>
+              <div class="project-links">
+                <a href="https://github.com/cortega26/FastSearchAPI#api-reference" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Referencia de la API</a>
+              </div>
+              <a href="https://github.com/cortega26/FastSearchAPI" class="btn btn-primary">Ver proyecto en GitHub</a>
+            </div>
+          </div>
+        </div>
+
+        <!-- Project 6 Card -->
+        <div class="col-md-6">
+          <div class="card mb-4 custom-card">
+            <div class="card-body text-center">
+              <h4 class="card-title">File Extractor Pro</h4>
+              <p class="card-text">Suite de automatización de escritorio que inventaría carpetas, aplica filtros de cumplimiento y genera reportes de extracción con evidencia anti-manipulación.</p>
+              <div class="project-badges">
+                <span class="badge badge-tech">Python</span>
+                <span class="badge badge-tech">Tkinter</span>
+                <span class="badge badge-tech">AsyncIO</span>
+              </div>
+              <ul class="project-details text-left">
+                <li><strong>Aporte:</strong> Diseñé el motor asíncrono de extracción, reforcé el logging estructurado y entregué un centro de mando en Tkinter para revisores no técnicos.</li>
+                <li><strong>Stack:</strong> Python 3.9+, Tkinter, asyncio, registros auditables con RotatingFileHandler.</li>
+                <li><strong>Volumen:</strong> Procesa árboles de directorios grandes sin congelar la interfaz gracias a workers en segundo plano.</li>
+                <li><strong>Impacto:</strong> Permite a equipos de cumplimiento exportar evidencias bajo demanda sin triage manual de archivos.</li>
+              </ul>
+              <div class="project-links">
+                <a href="https://github.com/cortega26/File-Extractor-Pro#features" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Resumen de funcionalidades</a>
+              </div>
+              <a href="https://github.com/cortega26/File-Extractor-Pro" class="btn btn-primary">Ver proyecto en GitHub</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- Contact Section -->
+  <section class="contact" id="contact">
+    <div class="container">
+      <h2 class="text-center">Contacto</h2><br>
+      <div class="row">
+        <div class="col-lg-5 mb-4">
+          <div class="contact-summary h-100">
+            <p>Construyamos productos de datos resilientes. Comparte un brief o invítame a una llamada de descubrimiento; responderé con próximos pasos y recursos alineados a tu hoja de ruta.</p>
+            <div class="contact-actions">
+              <a class="btn btn-cta contact-btn" href="mailto:carlosortega77@gmail.com?subject=Solicitud%20de%20CV" rel="noopener">Solicitar CV</a>
+              <a class="btn btn-outline-light contact-btn" href="https://www.linkedin.com/in/cortega26" target="_blank" rel="noopener">Conectar en LinkedIn</a>
+              <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar vía Calendly</a>
+            </div>
+            <p class="contact-response">Tiempo estimado de respuesta: dentro de 48 horas hábiles, con disponibilidad para llamadas martes a jueves, 9:00–15:00 CLT.</p>
+            <p class="contact-response">¿Necesitas respuesta urgente? Escríbeme directo y priorizaré incidentes en producción.</p>
+          </div>
+        </div>
+        <div class="col-lg-7 mb-4">
+          <form class="contact-form" id="contact-form">
+            <div class="form-group">
+              <label class="sr-only" for="name">Tu nombre</label>
+              <input type="text" class="form-control" id="name" name="name" placeholder="Tu nombre" required>
+            </div>
+            <div class="form-group">
+              <label class="sr-only" for="email">Tu correo</label>
+              <input type="email" class="form-control" id="email" name="email" placeholder="Tu correo" required>
+            </div>
+            <div class="form-group">
+              <label class="sr-only" for="subject">Asunto</label>
+              <input type="text" class="form-control" id="subject" name="subject" placeholder="Proyecto o rol" required>
+            </div>
+            <div class="form-group">
+              <label class="sr-only" for="message">Mensaje</label>
+              <textarea class="form-control" id="message" name="message" rows="5" placeholder="Comparte contexto, plazos y objetivos" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary contact-submit">Abrir borrador de correo</button>
+          </form>
+        </div>
+      </div>
+
+      <!-- Social Networks -->
+      <div class="container text-center">
+        <div class="social-media-container">
+          <div class="social-media-buttons btn-group">
+            <a href="https://github.com/cortega26" class="btn btn-dark"><i class="fab fa-github"></i></a>
+            <a href="https://www.linkedin.com/in/cortega26" class="btn btn-primary"><i class="fab fa-linkedin"></i></a>
+            <a href="https://twitter.com/cortega26" class="btn btn-dark"><i class="fab fa-twitter"></i></a>
+            <a href="https://wa.me/56951118901" class="btn btn-success"><i class="fab fa-whatsapp"></i></a>
+            <a href="mailto:carlosortega77@gmail.com" class="btn btn-dark"><i class="far fa-envelope"></i></a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="./spanish/script.js"></script>
+
 </body>
+
 </html>

--- a/spanish/script.js
+++ b/spanish/script.js
@@ -1,0 +1,163 @@
+
+// For example, smooth scrolling to sections on clicking nav links
+
+$(document).ready(function() {
+  $(".nav-link").on("click", function(event) {
+    event.preventDefault();
+    const target = $(this).attr("href");
+    $("html, body").animate({
+      scrollTop: $(target).offset().top
+    }, 800);
+  });
+});
+
+
+/* // Define an array of engaging messages
+const messages = [
+    "It's about 3.1416 \nThis is not a Sandra Bullock movie",
+    "Congratulations! You've unlocked the power of π. But beware, secrets come with a price...",
+    "Spiders crawl, secrets beckon. How deep will you venture into the digital abyss?",
+    "The cosmos whisper, the code calls. A universe of mysteries awaits...",
+    "A portal to the unknown has been opened. The ancient symbol of π reveals hidden truths...",
+    "Illuminating the shadows of the digital realm, you've embarked on a thrilling quest...",
+    "Binary whispers echo through the cyberspace. The enigma of π holds untold wonders...",
+    "Decoding the language of numbers, you've awakened a dormant power within...",
+    "The world of possibilities unfolds before you. The journey has just begun...",
+  ];
+  
+  // Initialize click count
+  let clickCount = 0;
+  
+  function showPiMessage() {
+    // Check if all messages have been displayed
+    if (clickCount === messages.length) {
+      // Last message with the call to action
+      const finalMessage = "I hope you had enough fun, now it's time to hire me. Let's create something extraordinary together!";
+      alert(finalMessage);
+    } else {
+      // Get the current message based on the click count
+      const message = messages[clickCount % messages.length];
+  
+      // Increment click count for the next click
+      clickCount++;
+  
+      alert(message);
+    }
+  } */
+
+
+// Define messages for English
+const messagesEn = [
+  "It's about 3.1416 \nThis is not a Sandra Bullock movie",
+    "Congratulations! You've unlocked the power of π. But beware, secrets come with a price...",
+    "Spiders crawl, secrets beckon. How deep will you venture into the digital abyss?",
+    "The cosmos whisper, the code calls. A universe of mysteries awaits...",
+    "A portal to the unknown has been opened. The ancient symbol of π reveals hidden truths...",
+    "Illuminating the shadows of the digital realm, you've embarked on a thrilling quest...",
+    "Binary whispers echo through the cyberspace. The enigma of π holds untold wonders...",
+    "Decoding the language of numbers, you've awakened a dormant power within...",
+    "The world of possibilities unfolds before you. The journey has just begun...",
+];
+
+// Define messages for Spanish
+const messagesEs = [
+  "¡Es sobre 3.1416! \nEsto no es una película de Sandra Bullock",
+  "¡Felicidades! Has desbloqueado el poder de π. Pero cuidado, los secretos tienen un precio...",
+  "Las arañas se deslizan, los secretos llaman. ¿Qué tan profundo te atreves a ir en el abismo digital?",
+  "El cosmos susurra y el código llama. Un universo de misterios te espera...",
+  "Se ha abierto un portal a lo desconocido. El símbolo ancestral de π revela verdades ocultas...",
+  "Iluminaste las sombras del reino digital; te embarcaste en una aventura emocionante...",
+  "Susurros binarios recorren el ciberespacio. El enigma de π guarda maravillas indescriptibles...",
+  "Al descifrar el lenguaje de los números despertaste un poder latente...",
+  "El mundo de posibilidades se despliega ante ti. El viaje apenas comienza...",
+];
+
+// Initialize click count
+let clickCount = 0;
+
+function showPiMessage() {
+  // Check the value of the lang attribute
+  const langAttribute = document.documentElement.getAttribute("lang");
+  
+  // Determine the messages based on the language
+  const isSpanish = langAttribute && langAttribute.startsWith("es");
+
+  let messages;
+  if (isSpanish) {
+      messages = messagesEs;
+  } else {
+      messages = messagesEn;
+  }
+
+  // Check if all messages have been displayed
+  if (clickCount === messages.length) {
+      // Last message with the call to action
+      const finalMessage = isSpanish
+        ? "Espero que te hayas divertido, ahora es momento de contratarme. ¡Creemos algo extraordinario juntos!"
+        : "I hope you had enough fun, now it's time to hire me. Let's create something extraordinary together!";
+      alert(finalMessage);
+  } else {
+      // Get the current message based on the click count
+      const message = messages[clickCount % messages.length];
+
+      // Increment click count for the next click
+      clickCount++;
+
+      alert(message);
+  }
+}
+
+
+
+
+
+
+
+function sendEmailFallback(event) {
+  const contactForm = document.getElementById("contact-form");
+
+  if (!contactForm) {
+    return;
+  }
+
+  event.preventDefault();
+
+  const langAttribute = document.documentElement.getAttribute("lang");
+  const isSpanish = langAttribute && langAttribute.startsWith("es");
+
+  const name = contactForm.elements["name"].value.trim();
+  const email = contactForm.elements["email"].value.trim();
+  const subject = contactForm.elements["subject"].value.trim();
+  const message = contactForm.elements["message"].value.trim();
+
+  const fallbackSubject = isSpanish ? "Consulta de portafolio" : "Portfolio Inquiry";
+  const composedSubject = subject
+    ? `${subject} — ${name || fallbackSubject}`
+    : `${fallbackSubject} ${isSpanish ? "de" : "from"} ${name || (isSpanish ? "Visita al sitio web" : "Website Visitor")}`;
+  const bodyLines = [
+    `${isSpanish ? "Nombre" : "Name"}: ${name || (isSpanish ? "No proporcionado" : "Not provided")}`,
+    `${isSpanish ? "Correo" : "Email"}: ${email || (isSpanish ? "No proporcionado" : "Not provided")}`,
+    "",
+    message || "",
+  ];
+
+  const mailtoLink = `mailto:carlosortega77@gmail.com?subject=${encodeURIComponent(composedSubject)}&body=${encodeURIComponent(bodyLines.join("\n"))}`;
+
+  window.location.href = mailtoLink;
+
+  setTimeout(() => {
+    contactForm.reset();
+  }, 300);
+
+  alert(isSpanish
+    ? "Los detalles de tu mensaje se prepararon en tu cliente de correo. Revísalos y envíalos para completar el contacto."
+    : "Your message details have been prepared in your email client. Please review and send it to complete your outreach.");
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+  const contactForm = document.getElementById("contact-form");
+
+  if (contactForm) {
+    contactForm.addEventListener("submit", sendEmailFallback);
+  }
+});

--- a/spanish/style.css
+++ b/spanish/style.css
@@ -1,0 +1,372 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap');
+
+body {
+    font-family: 'Montserrat', 'Courier New', monospace;
+    background-color: black;
+    color: white;
+  }
+  
+  .navbar {
+    background-color: black !important;
+    font-family: Arial, Helvetica, sans-serif;
+  }
+  
+  .navbar-brand {
+    font-size: 18px;
+  }
+
+  .navbar-nav {
+    font-size: 14px;
+  }
+
+  .landing {
+    background: linear-gradient(to bottom, black, #333);
+    padding: 80px 0;
+  }
+
+.hero-cta {
+  margin-top: 24px;
+}
+
+.hero-cta .btn {
+  font-weight: 600;
+  padding: 12px 28px;
+  border-radius: 50px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-highlights {
+  list-style: none;
+  padding: 0;
+  margin: 24px auto 0;
+  max-width: 640px;
+  text-align: left;
+}
+
+.hero-highlights li {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  margin-bottom: 14px;
+  padding-left: 28px;
+  position: relative;
+}
+
+.hero-highlights li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: #00d1ff;
+  font-size: 1.3rem;
+  line-height: 1.6;
+}
+
+.hero-cta .btn-primary {
+  background-color: #007bff;
+  border-color: #007bff;
+}
+
+.hero-cta .btn-cta {
+  background-color: #00d1ff;
+  border-color: #00d1ff;
+  color: #000;
+  box-shadow: 0 8px 18px rgba(0, 209, 255, 0.3);
+}
+
+.hero-cta .btn-cta:hover {
+  background-color: #1ae0ff;
+  border-color: #1ae0ff;
+  color: #000;
+}
+
+.hero-cta .btn-primary:hover,
+.hero-cta .btn-outline-light:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+}
+
+.hero-cta .btn-outline-light {
+  color: #fff;
+  border-color: #f8f9fa;
+}
+
+.hero-cta .btn-outline-light:hover {
+  background-color: #f8f9fa;
+  color: #000;
+}
+
+@media (max-width: 576px) {
+  .hero-highlights {
+    margin-top: 20px;
+    padding: 0 16px;
+  }
+
+  .hero-highlights li {
+    font-size: 1rem;
+  }
+
+  .hero-cta .btn {
+    width: 100%;
+  }
+}
+
+  .profile-image {
+    width: 360px;
+    height: 360px;
+    border-radius: 50%;
+    margin-top: 26px;
+    margin-bottom: 26px;
+    border: 5px solid white;
+  }
+  
+h2 {
+  font-family: 'Arial', sans-serif; /* Choose a font that suits your preference */
+  font-size: 36px; /* Adjust the size as needed */
+  font-weight: bold;
+}
+
+.about p {
+  font-size: 18px; /* Adjust the size as needed */
+  line-height: 1.6; /* Add line height for better readability */
+  margin-bottom: 26px;
+}
+
+.about-intro {
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+.about-highlights {
+  list-style: none;
+  max-width: 880px;
+  margin: 32px auto 0;
+  padding: 0;
+}
+
+.about-highlights li {
+  font-size: 18px;
+  line-height: 1.7;
+  margin-bottom: 18px;
+  padding-left: 28px;
+  position: relative;
+}
+
+.about-highlights li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: #00d1ff;
+  font-size: 1.4rem;
+  line-height: 1.6;
+}
+
+.about,
+  .portfolio,
+  .contact {
+    padding: 100px 0;
+  }
+
+  #pi {
+    font-family: Times, serif, Arial, Helvetica, sans-serif, serif;
+  }
+
+.contact-summary {
+  background-color: #111;
+  border: 1px solid #222;
+  border-radius: 16px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.contact-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.contact .btn {
+  font-weight: 600;
+  border-radius: 999px;
+}
+
+.contact-btn {
+  width: 100%;
+  text-align: center;
+}
+
+.contact-response {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin-bottom: 8px;
+  color: #d0d0d0;
+}
+
+.contact-submit {
+  padding: 12px 28px;
+  width: 100%;
+}
+
+.contact-form .form-group {
+  margin-bottom: 18px;
+}
+
+.contact-form .form-control {
+  background-color: #0a0a0a;
+  border-color: #333;
+  color: #fff;
+}
+
+.contact-form .form-control:focus {
+  box-shadow: 0 0 0 0.2rem rgba(0, 209, 255, 0.25);
+  border-color: #00d1ff;
+}
+
+@media (min-width: 576px) {
+  .contact-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .contact-btn {
+    flex: 1 1 180px;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .contact-summary {
+    padding: 24px 20px;
+  }
+}
+
+.social-media-buttons a.btn.btn-dark,
+.social-media-buttons a.btn.btn-primary,
+.social-media-buttons a.btn.btn-success {
+  border-radius: 50% !important;
+  width: 40px; /* Set a fixed width */
+  height: 40px; /* Set a fixed height */
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.social-media-buttons .btn-dark,
+.social-media-buttons a.btn.btn-primary,
+.social-media-buttons .btn-success {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.social-media-buttons .btn-dark i,
+.social-media-buttons a.btn.btn-primary,
+.social-media-buttons .btn-success i {
+  font-size: 24px;
+}
+
+
+.custom-card {
+  background-color: black;
+  color: white;
+  border: 1px solid #333;
+}
+
+.project-badges {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0 6px;
+}
+
+.badge-tech {
+  background-color: #1ae0ff;
+  color: #000;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.75rem;
+  letter-spacing: 0.4px;
+}
+
+.card-body .project-details {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 16px;
+}
+
+.card-body .project-details li {
+  text-align: left;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin-bottom: 8px;
+  position: relative;
+  padding-left: 20px;
+}
+
+.card-body .project-details li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: #00d1ff;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.project-links {
+  margin-bottom: 12px;
+}
+
+.project-links .btn {
+  margin: 0 4px 8px;
+}
+
+
+.certifications {
+  background-color: #333;
+  color: white;
+  padding: 100px 0;
+}
+
+.certifications h2 {
+  font-size: 36px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.certifications ul {
+  list-style: none;
+  padding: 0;
+}
+
+.certifications li {
+  margin-bottom: 20px;
+  border: 1px solid white;
+  padding: 20px;
+}
+
+.certifications li strong {
+  font-size: 20px;
+  display: block;
+}
+
+.certifications li span {
+  display: block;
+  margin-top: 8px;
+  font-size: 14px;
+}
+
+.certifications li a {
+  color: white;
+  text-decoration: none;
+}
+
+.certifications li a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- replace the legacy Spanish index with the translated single-page layout used by the English site
- add Spanish-specific stylesheet with typography tweaks and localized script behaviors
- localize interactive messaging, CTAs, and contact form defaults for Spanish visitors

## Testing
- python3 -m http.server 8000 (manually inspected index-spa.html)


------
https://chatgpt.com/codex/tasks/task_e_68d76c30f1b0832f99fc6c6a35f6c43c