### PR TITLE
Add résumé download asset and update CTAs

### DIFF
--- a/assets/docs/carlos-ortega-resume.pdf
+++ b/assets/docs/carlos-ortega-resume.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250927045750+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250927045750+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (Carlos Ortega Resume) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 496
+>>
+stream
+GarW695iQ=&;9NJ'm"JS=L"*t!IW%b:3-\EUXcUcMHi^]-rM0hE<>4AGH%A=$laL)`+WcW>F&C5<R,MG!4Oi2mn8l[l5&JmEJaN(S,,PHb7Ei;-2.c>+Nb%:eY8LTM`VYZ8GEpf3d$>V$2'W0IZ$Fajdh9^NUNqrMZ:(7/@2%dU@)m8k`hr.3(";Jn&<m69genfqu%R>Gr11FZcZZg\Hhj3VjJ+WR:<J<6R>9V+]BAXg]c"ro30@Yjk'.!L=&kl_gj]DYl$14CNSPu20nduLUjnZgS*6]AYa"]CI2sOhT<ZL]gncd.9mS;9E@fA:=_.Ce3K"gZWaV5SDIKG9iBX^IKi0Y;`]R%#2<5IKE#a5><GOD3eilbmGrEh?TBg>+b9_(3@c4+`aC.<#m,eI5^O8*juGu>(ptLo;h6ks$+H?9X:Wme8@GeKo'9ON#&J^38G(!-[uOG1F&KS>R!9+_EtY(]RV@8YL0.TF5-<r9iT)*=e'1J~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000526 00000 n 
+0000000594 00000 n 
+0000000902 00000 n 
+0000000961 00000 n 
+trailer
+<<
+/ID 
+[<03d31a48b77e57b5e2e193aa99d41183><03d31a48b77e57b5e2e193aa99d41183>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1547
+%%EOF

--- a/english/english.html
+++ b/english/english.html
@@ -49,7 +49,7 @@
         <li>Senior Python developer guiding cross-functional teams from concept to deployment</li>
       </ul>
       <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
-        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="mailto:carlosortega77@gmail.com?subject=Resume%20Request" rel="noopener">Request Résumé</a>
+        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="../assets/docs/carlos-ortega-resume.pdf" download>Download Résumé</a>
         <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Book a Discovery Call</a>
       </div>
     </div>

--- a/index-spa.html
+++ b/index-spa.html
@@ -49,7 +49,7 @@
         <li>Desarrollador senior de Python que guía equipos multifuncionales desde la idea hasta la puesta en producción.</li>
       </ul>
       <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
-        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="mailto:carlosortega77@gmail.com?subject=Solicitud%20de%20CV" rel="noopener">Solicitar CV</a>
+        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="assets/docs/carlos-ortega-resume.pdf" download>Descargar CV</a>
         <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar llamada de descubrimiento</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add the latest résumé PDF to the repository under assets/docs
- replace the English landing mailto résumé CTA with a direct download button while keeping the Calendly option
- mirror the résumé download button in the Spanish landing with localized text

## Testing
- Manually opened english/english.html via python -m http.server to verify the new download button

------
https://chatgpt.com/codex/tasks/task_e_68d76eaf8124832fbbe3620cafabd241