### PR TITLE
Add downloadable resume access across portfolio

### DIFF
--- a/assets/docs/carlos-ortega-resume.pdf
+++ b/assets/docs/carlos-ortega-resume.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250927050029+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250927050029+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1235
+>>
+stream
+Gat=*gMZ%0&:NH>R$STC2HFq-ih-f^*6%51=hBfZU5OGn-!FnTP:B-MFg)t&URSk'"=RdtYj'P[k&AV6)*;6dbA#l*"2IV8QZip!/nA1*I*79rJN/#.g0J[b`pS:cFnu*3$_cTa=-+H\rB,Bs<[k*kZ?Qtt@eK9?B?taapsW$#r=.H+Vhg_^CGQ.FoZ`cPR;5Oq2J?h>0skIO7"Xp'@C_+M;+=@c?Qc1s8HnFTfgu4RoU0`&;>!CFVbQAXmb8%8fCHOX`!=0S2<7/FWMRJe,Rf/Q)lo7I""$a0f[F:YY(=&0-CP1+9O-_N^H3GH+:+D`R")rrLO+"N,r</ZdmcNT`T2*WW@7PH6.haBG8[%+$a!R$qV.XQs%AJi%hq/qa^YbDj8FDunCRI5[QTk(EamTjfJ6lK^:Spn\=lOD]N35r07\i[Wd;Q[&SO#B5,Y2A%mU:4`/mQafJ=88,Uj5!dai)&_3NW90nH8]nph&u5gcn"";;j87B6<Pb86.-;_,[P#sNM=BdB\flsu*#:l+U:NAmTs$k1UXVZfB1V9kC3U;\hrIY!+8MDU=?hH3^O!R$0c;ku#m:$"?I,o&EDNRDM0;,K)7c`)YK2)%1E"9E2K<.X/f!bLK=!6LMU\o5Fn8H24AQ>VuoMA\klntG"G"V%fk&!/+MOCC^[KC942Sn!&pd=MgHY1`cH>!9fc`UaV8F8Ib3@&9JUTA=2eG=7p6^$NJkrOYFU&UO8W_=KjA4/lnR5A3T%D7<%Z4>C+Tc<a`4n[QI#^es`:g4tsh*Ym>!f2A)9d1`lEnj@MC^7h>\Cg6L1el?A*p5OaFO&8-/SO8D*])sp)SAb"-ednh=nM;2H^i]j5)H(N?&=)^W,KC8P=!t62TOE*RcW%/$b<'`j%D,Y[%lnCu[2C)$>GjHU@sm#QfXPF]6MrJhZ$'*KQ0`HXqC$C"a^&mURPq"5:P2*f$lcfq(IJZl74.Yp'iZ#<<8j?3"-IdBp;FUNhqh'_bgu11f2a%#ke?26iBAbhL"Ng[eQlIbO8&9+WHJWh$ksCgEr2M='h.jQqUZ,BJaKk^6:71l;H3g\rs!?e3@@kQTk`DPqWs]KdH%hY\G_eCTlc?"E'0/Rs5Pk,X.C,05prl^qRCd/(3'[G6M(sDPNZVH/@4jsd)0Z_40^1odlY'mZm)5)D,.0Sh24$'8._Rbi+O_("jHk@?<&CW>QTd(,ROh=[QA@@_p'M'pOaREI0CPCZK(~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000526 00000 n 
+0000000594 00000 n 
+0000000890 00000 n 
+0000000949 00000 n 
+trailer
+<<
+/ID 
+[<7ba1615bd85da1ce44df5f7d614966d2><7ba1615bd85da1ce44df5f7d614966d2>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2275
+%%EOF

--- a/english/english.html
+++ b/english/english.html
@@ -49,7 +49,9 @@
         <li>Senior Python developer guiding cross-functional teams from concept to deployment</li>
       </ul>
       <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
-        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="mailto:carlosortega77@gmail.com?subject=Resume%20Request" rel="noopener">Request Résumé</a>
+        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="../assets/docs/carlos-ortega-resume.pdf" download>
+          Download Résumé
+        </a>
         <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Book a Discovery Call</a>
       </div>
     </div>
@@ -285,12 +287,13 @@
           <div class="contact-summary h-100">
             <p>Let's build resilient data products together. Share a short brief or invite me to a discovery call—I'll respond with next steps and resources tailored to your roadmap.</p>
             <div class="contact-actions">
-              <a class="btn btn-cta contact-btn" href="mailto:carlosortega77@gmail.com?subject=Resume%20Request" rel="noopener">Request Résumé</a>
+              <a class="btn btn-cta contact-btn" href="../assets/docs/carlos-ortega-resume.pdf" download>Download Résumé</a>
               <a class="btn btn-outline-light contact-btn" href="https://www.linkedin.com/in/cortega26" target="_blank" rel="noopener">Connect on LinkedIn</a>
               <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Schedule via Calendly</a>
             </div>
             <p class="contact-response">Preferred response window: within 48 business hours, with calls available Tuesday–Thursday, 9:00–15:00 CLT.</p>
             <p class="contact-response">Need a faster answer? Email me directly and I'll prioritize urgent production issues.</p>
+            <p class="contact-response">Open to remote or hybrid engagements across the Americas and Europe.</p>
           </div>
         </div>
         <div class="col-lg-7 mb-4">

--- a/index-spa.html
+++ b/index-spa.html
@@ -49,7 +49,9 @@
         <li>Desarrollador senior de Python que guía equipos multifuncionales desde la idea hasta la puesta en producción.</li>
       </ul>
       <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
-        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="mailto:carlosortega77@gmail.com?subject=Solicitud%20de%20CV" rel="noopener">Solicitar CV</a>
+        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="../assets/docs/carlos-ortega-resume.pdf" download>
+          Descargar CV
+        </a>
         <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar llamada de descubrimiento</a>
       </div>
     </div>
@@ -283,12 +285,13 @@
           <div class="contact-summary h-100">
             <p>Construyamos productos de datos resilientes. Comparte un brief o invítame a una llamada de descubrimiento; responderé con próximos pasos y recursos alineados a tu hoja de ruta.</p>
             <div class="contact-actions">
-              <a class="btn btn-cta contact-btn" href="mailto:carlosortega77@gmail.com?subject=Solicitud%20de%20CV" rel="noopener">Solicitar CV</a>
+              <a class="btn btn-cta contact-btn" href="../assets/docs/carlos-ortega-resume.pdf" download>Descargar CV</a>
               <a class="btn btn-outline-light contact-btn" href="https://www.linkedin.com/in/cortega26" target="_blank" rel="noopener">Conectar en LinkedIn</a>
               <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar vía Calendly</a>
             </div>
             <p class="contact-response">Tiempo estimado de respuesta: dentro de 48 horas hábiles, con disponibilidad para llamadas martes a jueves, 9:00–15:00 CLT.</p>
             <p class="contact-response">¿Necesitas respuesta urgente? Escríbeme directo y priorizaré incidentes en producción.</p>
+            <p class="contact-response">Abierto a roles remotos o híbridos en América y Europa.</p>
           </div>
         </div>
         <div class="col-lg-7 mb-4">


### PR DESCRIPTION
## Summary
- add a downloadable résumé CTA to the English hero and contact sections
- mirror the résumé download and availability messaging on the Spanish page
- publish a concise bilingual résumé PDF for quick recruiter access

## Testing
- Not run (static content updates)


------
https://chatgpt.com/codex/tasks/task_e_68d76189e778832f817ec47a79772380