### PR TITLE
Revamp bilingual portfolio pages for cohesive UX

### DIFF
--- a/english/english.html
+++ b/english/english.html
@@ -1,520 +1,469 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Carlos Ortega's Portfolio</title>
+  <title>Carlos Ortega González · Analytics Engineering Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
   <link rel="stylesheet" href="./english/style.css">
 </head>
-
 <body>
-  <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Primary navigation">
     <div class="container">
-      <a class="navbar-brand" href="#" id="pi" onclick="showPiMessage()">π</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <a class="navbar-brand" href="#overview" id="pi" onclick="showPiMessage()" aria-label="Playful PI easter egg">π</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ml-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="#about">About</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#strengths">Strengths</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#roadmap">Roadmap</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#certifications">Certifications</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#portfolio">Portfolio</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#math-lab">Math Lab</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#contact">Contact</a>
-          </li>
+          <li class="nav-item"><a class="nav-link" href="#overview">Overview</a></li>
+          <li class="nav-item"><a class="nav-link" href="#about">Profile</a></li>
+          <li class="nav-item"><a class="nav-link" href="#capabilities">Capabilities</a></li>
+          <li class="nav-item"><a class="nav-link" href="#experience">Experience</a></li>
+          <li class="nav-item"><a class="nav-link" href="#credentials">Credentials</a></li>
+          <li class="nav-item"><a class="nav-link" href="#portfolio">Portfolio</a></li>
+          <li class="nav-item"><a class="nav-link" href="#math-lab">Math Lab</a></li>
+          <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
         </ul>
       </div>
     </div>
   </nav>
 
-  <!-- Landing Section -->
-  <header class="landing" id="home">
-    <div class="container text-center">
-      <img class="profile-image" src="./english/Me&wify.png" alt="Carlos Ortega">
-      <h1 class="display-4">Carlos Ortega González</h1>
-      <ul class="hero-highlights">
-        <li>Operations leader turned analytics engineer translating ambiguous risk problems into Python-first solutions.</li>
-        <li>Delivered 420 quarterly analyst hours back to product teams and shipped fraud lookups that run 6× faster.</li>
-        <li>Partner to fintech, cybersecurity, and public-sector innovators across Chile, LATAM, and remote US teams.</li>
-      </ul>
-      <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
-        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="../assets/docs/carlos-ortega-resume.pdf" download>Download Résumé</a>
-        <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Book a Discovery Call</a>
-      </div>
-      <ul class="hero-meta">
-        <li><strong>Roles:</strong> Senior Data Analyst · Analytics Engineer · Technical Product Manager</li>
-        <li><strong>Location:</strong> Santiago, Chile · Open to remote/hybrid across LATAM &amp; US-friendly time zones</li>
-        <li><strong>Availability:</strong> 30 days notice · Contract or full-time · Eligible to invoice internationally</li>
-      </ul>
-    </div>
-  </header>
-
-  <!-- About Section -->
-  <section class="about" id="about">
-    <div class="container">
-      <h2 class="text-center">About Me</h2><br>
-
-      <p class="about-intro">I’m a bilingual (ES/EN) builder who pairs 15+ years of operations rigor with modern analytics engineering. After stewarding national security logistics programs, I pivoted into math-forward automation—standing up Python, SQL, and FastAPI products that compress fraud investigations, compliance reviews, and executive reporting cycles.</p>
-
-      <div class="about-grid">
-        <article class="about-card">
-          <h3>Career Snapshot</h3>
-          <ul class="about-highlights">
-            <li>Automated regulatory reporting workflows that return 420 analyst hours per quarter to roadmap execution.</li>
-            <li>Engineered analytics pipelines consolidating 65+ disparate datasets for fraud intelligence and risk scoring.</li>
-            <li>Led cross-functional squads of 8 engineers and analysts to deliver Python- and SQL-driven insights with 99% SLA adherence.</li>
-          </ul>
-        </article>
-        <article class="about-card">
-          <h3>Community &amp; Learning</h3>
-          <ul class="about-highlights">
-            <li>Active contributor to Python Chile, fintech security meetups, and analytics Slack communities.</li>
-            <li>Documenting every project in GitHub READMEs, issue roadmaps, and Loom walkthroughs to showcase repeatability.</li>
-            <li>Currently tackling advanced statistics, optimization, and AWS data analytics coursework to sharpen math depth.</li>
-          </ul>
-        </article>
-      </div>
-    </div>
-  </section>
-
-  <!-- Strengths Section -->
-  <section class="strengths" id="strengths">
-    <div class="container">
-      <h2 class="text-center">Transferable Strengths</h2>
-      <p class="section-subtitle text-center">The same leadership and analytical instincts that delivered complex operations programs now accelerate data teams.</p>
-      <div class="row">
-        <div class="col-md-4 mb-4">
-          <div class="strength-card h-100">
-            <h3>Automation Commander</h3>
-            <p>I blueprint end-to-end systems—from discovery to runbooks—so analysts can focus on decision-making, not repetitive prep.</p>
-            <ul>
-              <li>File Extractor Pro hardens audit trails and asynchronous processing for compliance reviewers.</li>
-              <li>PDF Text Analyzer normalizes multilingual corpora and flags anomalies 60% faster.</li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-md-4 mb-4">
-          <div class="strength-card h-100">
-            <h3>Math &amp; Model Translator</h3>
-            <p>I turn statistical insight into stakeholder-ready stories backed by reproducible notebooks and tests.</p>
-            <ul>
-              <li>Foobar and Google challenge repos catalog algorithmic solutions with Big-O analysis.</li>
-              <li>Backtest Trading experiments quantify risk scenarios before automations hit production.</li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-md-4 mb-4">
-          <div class="strength-card h-100">
-            <h3>Stakeholder Ally</h3>
-            <p>Cross-functional facilitation keeps security, finance, and engineering aligned around measurable ROI.</p>
-            <ul>
-              <li>Calibrated FastSearchAPI backlogs with support teams to guarantee &lt;150&nbsp;ms response times.</li>
-              <li>Maintained portfolio Kanban and release notes so exec sponsors saw continuous progress.</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Roadmap Section -->
-  <section class="roadmap" id="roadmap">
-    <div class="container">
-      <h2 class="text-center">Career Pivot Roadmap</h2>
-      <p class="section-subtitle text-center">A transparent timeline showing how operations leadership evolved into data automation and analytics engineering.</p>
-      <div class="roadmap-timeline">
-        <article class="roadmap-item">
-          <span class="roadmap-date">2021</span>
-          <h3>Automated macroeconomic storytelling</h3>
-          <p>Launched World Bank GDP per-capita automations and Flourish dashboards that executives reuse quarterly, unlocking new reporting cadences.</p>
-        </article>
-        <article class="roadmap-item">
-          <span class="roadmap-date">2022</span>
-          <h3>Formalized data foundations</h3>
-          <p>Completed Google Data Analytics, AWS ML Foundations, and Udacity specializations while rebuilding résumé and GitHub with quantified outcomes.</p>
-        </article>
-        <article class="roadmap-item">
-          <span class="roadmap-date">2023</span>
-          <h3>Production-ready APIs &amp; compliance tooling</h3>
-          <p>Released FastSearchAPI, File Extractor Pro, and PDF Text Analyzer with Docker, CI, and documentation to mirror enterprise delivery standards.</p>
-        </article>
-        <article class="roadmap-item">
-          <span class="roadmap-date">2024</span>
-          <h3>Decision intelligence &amp; streaming analytics</h3>
-          <p>Shipped Crypto Price Tracker alerts, PoGo rarity intelligence, and kicked off AWS Data Analytics Specialty prep with weekly public learning logs.</p>
-        </article>
-      </div>
-    </div>
-  </section>
-
-
-  <!-- Certifications Section -->
-    <section class="certifications" id="certifications">
+  <main>
+    <header class="landing" id="overview">
       <div class="container">
-        <h2 class="text-center">Certifications</h2><br>
-        <!-- List of Certifications -->
-        <ul>
-          <li>
-            <strong>In Progress: AWS Data Analytics Specialty</strong>
-            Self-study &amp; community labs | Target completion: Q4 2024
-          </li>
-          <li>
-            <strong><a href="https://www.udemy.com/certificate/UC-6516cd74-a25b-405d-962d-f3f6296db1c0/">Automate the boring stuff with Python Programming</a></strong>
-            Udemy | Issued: december 2022
-          </li>
-          <li>
-            <strong><a href="https://www.credly.com/badges/7b6d0fbb-81b4-4b90-a07a-ad49506619cc/linked_in_profile">Data Science Orientation</a></strong>
-            Coursera | Issued: october 2022
-          </li>
-          <li>
-            <strong><a href="https://graduation.udacity.com/confirm/KVWVKZFW">AWS Machine Learning Foundations</a></strong>
-            Udacity | Issued: september 2022
-          </li>
-          <li>
-            <strong><a href="https://www.efset.org/cert/W91jYa">EF SET English Certificate</a></strong>
-            EF | Issued: june 2022
-          </li>
-          <li>
-            <strong><a href="https://www.credly.com/badges/bfe5a0e2-b688-4300-be52-97d4ca8d6f6e/public_url">Google Data Analytics</a></strong>
-            Coursera | Issued: may 2022
-          </li>
-          <li>
-            <strong><a href="https://www.udemy.com/certificate/UC-0d585a57-068e-4d51-9360-48283b103059/?utm_campaign=email&utm_source=sendgrid.com&utm_medium=email">The Self-Taught Programmer</a></strong>
-            Udemy | Issued: march 2022
-          </li>
-          <li>
-            <strong><a href="https://www.udemy.com/certificate/UC-333e6d66-a544-475f-8cf7-747487ad2bc0/">Business Intelligence Analyst</a></strong>
-            Udemy | Issued: october 2021
-          </li>
-          <li><strong><a href="https://www.credly.com/badges/01c42a0d-8939-41e4-8d26-73a796a95594/public_url">SCRUM Foundation Professional</a></strong>
-            CertiProf | Issued: november 2020 (last updated may 2023)
-          </li>
-          <li>
-            <strong><a href="https://www.credly.com/badges/6396404d-ef8e-4388-b3d2-4f858afea8f9">Cisco Certified Network Associate Routing and Switching (CCNA R&S)</a></strong>
-            Cisco | Issued: september 2016
-          </li>
-        </ul>
+        <div class="row align-items-center hero-layout">
+          <div class="col-lg-6">
+            <span class="hero-eyebrow">Analytics engineering &amp; risk automation leader</span>
+            <h1 class="display-4">Carlos Ortega González</h1>
+            <p class="hero-lede">I orchestrate bilingual data teams that transform ambiguous risk, compliance, and product challenges into auditable Python, SQL, and API solutions.</p>
+            <ul class="hero-highlights">
+              <li>Returned <strong>420 quarterly analyst hours</strong> to product execution through regulatory reporting automation.</li>
+              <li>Delivered a <strong>6× faster fraud lookup experience</strong> by engineering FastAPI services and asynchronous data pipelines.</li>
+              <li>Trusted partner to fintech, cybersecurity, and public-sector innovators across Chile, LATAM, and remote U.S. squads.</li>
+            </ul>
+            <div class="hero-cta d-flex flex-column flex-sm-row align-items-sm-center">
+              <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="../assets/docs/carlos-ortega-resume.pdf" download>Download Résumé</a>
+              <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Book a Discovery Call</a>
+            </div>
+          </div>
+          <div class="col-lg-5 offset-lg-1">
+            <figure class="hero-figure">
+              <img class="profile-image" src="./english/Me&wify.png" alt="Portrait of Carlos Ortega">
+              <figcaption>Based in Santiago, Chile · Open to remote or hybrid roles within LATAM and U.S.-friendly time zones.</figcaption>
+            </figure>
+            <div class="hero-meta-grid" role="list">
+              <article class="hero-meta-card" role="listitem">
+                <h3>Roles in scope</h3>
+                <p>Senior Data Analyst · Analytics Engineer · Technical Product Manager</p>
+              </article>
+              <article class="hero-meta-card" role="listitem">
+                <h3>Engagement models</h3>
+                <p>Full-time or contract · 30-day notice · Eligible to invoice internationally</p>
+              </article>
+              <article class="hero-meta-card" role="listitem">
+                <h3>Collaboration style</h3>
+                <p>Discovery workshops, agile cadences, and executive-ready storytelling backed by reproducible assets.</p>
+              </article>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <section class="about" id="about">
+      <div class="container">
+        <h2 class="section-title text-center">Profile at a Glance</h2>
+        <p class="section-intro text-center">I combine 15+ years of operations leadership with modern analytics engineering to deliver resilient data products. My approach blends discovery facilitation, math-first experimentation, and production-grade automation—so decision-makers ship faster with less risk.</p>
+        <div class="about-grid">
+          <article class="about-card">
+            <h3>Who I support</h3>
+            <ul class="about-list">
+              <li>Fintech, cybersecurity, and public agencies navigating high-stakes regulatory and fraud workloads.</li>
+              <li>Scale-ups needing bilingual data storytellers to align engineering, finance, and executive sponsors.</li>
+              <li>Operations-heavy teams modernizing spreadsheets into API-driven, observable platforms.</li>
+            </ul>
+          </article>
+          <article class="about-card">
+            <h3>How I operate</h3>
+            <ul class="about-list">
+              <li>Blueprint cross-functional discovery to clarify requirements, success metrics, and risk posture.</li>
+              <li>Ship modular Python, SQL, and FastAPI services with CI, documentation, and knowledge transfer baked in.</li>
+              <li>Maintain transparent GitHub roadmaps, Loom walkthroughs, and stakeholder updates to sustain trust.</li>
+            </ul>
+          </article>
+          <article class="about-card">
+            <h3>Currently focused on</h3>
+            <ul class="about-list">
+              <li>Advanced statistics, optimization, and AWS Data Analytics Specialty preparation.</li>
+              <li>Streaming architectures that surface real-time anomalies for security and trading teams.</li>
+              <li>Mentoring community builders in Python Chile and analytics Slack groups.</li>
+            </ul>
+          </article>
+        </div>
       </div>
     </section>
 
-
-<!-- Portfolio Section -->
-  <section class="portfolio" id="portfolio">
-    <div class="container">
-      <h2 class="text-center">Portfolio</h2><br>
-      <p class="section-subtitle text-center">Case studies spanning automation, APIs, and interactive analytics. Each repository includes setup guides, issue roadmaps, and metrics to replicate the results.</p>
-
-      <div class="row">
-        <!-- Project 1 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Data Viz: Crecimiento PIB per cápita PPA</h4>
-              <p class="card-text">Bar Chart Race - Percentage growth of GDP per capita PPP ($ at current international prices) since 1990 in American countries.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">Flourish</span>
-                <span class="badge badge-tech">ETL</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Curated World Bank GDP datasets, automated cleaning scripts, and produced animated storytelling visuals.</li>
-                <li><strong>Tech stack:</strong> Pandas, Flourish Studio templates, GitHub Actions for scheduled refresh.</li>
-                <li><strong>Data volume:</strong> 31 years × 22 countries (~680 records) updated quarterly.</li>
-                <li><strong>Impact:</strong> Equipped executive briefings with ready-to-share assets, reducing manual chart prep by 3 hours per update.</li>
+    <section class="capabilities" id="capabilities">
+      <div class="container">
+        <h2 class="section-title text-center">Core Capabilities</h2>
+        <p class="section-subtitle text-center">Every engagement is anchored in measurable outcomes, collaborative rituals, and reusable assets.</p>
+        <div class="row">
+          <div class="col-md-4 mb-4">
+            <article class="capability-card h-100">
+              <h3>Automation Commander</h3>
+              <p>I turn fragmented manual processes into auditable, asynchronous workflows that free analysts to focus on judgment calls.</p>
+              <ul>
+                <li>File Extractor Pro standardizes evidence packs and resilience checks for compliance squads.</li>
+                <li>PDF Text Analyzer accelerates multilingual reviews with anomaly surfacing 60% faster.</li>
               </ul>
-              <a href="https://public.flourish.studio/visualisation/9177797/" class="btn btn-primary">View Visualization</a>
-            </div>
+            </article>
+          </div>
+          <div class="col-md-4 mb-4">
+            <article class="capability-card h-100">
+              <h3>Math &amp; Model Translator</h3>
+              <p>I distill statistics and forecasting into plain-language narratives, complete with tests, notebooks, and reproducible pipelines.</p>
+              <ul>
+                <li>Foobar and Google challenge repos benchmark algorithmic rigor with Big-O analysis.</li>
+                <li>Backtest Trading notebooks quantify risk scenarios before automation hits production.</li>
+              </ul>
+            </article>
+          </div>
+          <div class="col-md-4 mb-4">
+            <article class="capability-card h-100">
+              <h3>Stakeholder Ally</h3>
+              <p>I facilitate cross-functional alignment so product, security, and finance teams rally around clear ROI and delivery cadences.</p>
+              <ul>
+                <li>FastSearchAPI roadmaps co-created with support teams to guarantee &lt;150&nbsp;ms latency.</li>
+                <li>Release notes and dashboards keep executives informed without disrupting maker time.</li>
+              </ul>
+            </article>
           </div>
         </div>
+      </div>
+    </section>
 
-        <!-- Project 2 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Data Viz: Inflación acumulada en países de la OCDE</h4>
-              <p class="card-text">Bar Chart Race - Cumulative inflation in the countries of the Organisation for Economic Co-operation and Development (OECD) from 1990 to 2020.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">Flourish</span>
-                <span class="badge badge-tech">OECD API</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Built extraction scripts against the OECD API and harmonized CPI indexes for cross-country comparability.</li>
-                <li><strong>Tech stack:</strong> Requests, Pandas, Flourish Studio, Airtable for annotation workflow.</li>
-                <li><strong>Data volume:</strong> 30 years × 38 OECD members (~1.1K records).</li>
-                <li><strong>Impact:</strong> Enabled policy analysts to surface inflation outliers in under 5 minutes, accelerating newsletter production.</li>
+    <section class="experience" id="experience">
+      <div class="container">
+        <h2 class="section-title text-center">Career Highlights</h2>
+        <p class="section-subtitle text-center">A transparent progression from national-security logistics to data automation leadership.</p>
+        <div class="roadmap-timeline">
+          <article class="roadmap-item">
+            <span class="roadmap-date">2021</span>
+            <h3>Automated macroeconomic storytelling</h3>
+            <p>Launched World Bank GDP per-capita automations and Flourish dashboards reused quarterly by executives, unlocking new reporting cadences.</p>
+          </article>
+          <article class="roadmap-item">
+            <span class="roadmap-date">2022</span>
+            <h3>Formalized data foundations</h3>
+            <p>Completed Google Data Analytics, AWS ML Foundations, and Udacity specializations while rebuilding résumé and GitHub with quantified outcomes.</p>
+          </article>
+          <article class="roadmap-item">
+            <span class="roadmap-date">2023</span>
+            <h3>Production-ready APIs &amp; compliance tooling</h3>
+            <p>Released FastSearchAPI, File Extractor Pro, and PDF Text Analyzer with Docker, CI, and documentation mirroring enterprise standards.</p>
+          </article>
+          <article class="roadmap-item">
+            <span class="roadmap-date">2024</span>
+            <h3>Decision intelligence &amp; streaming analytics</h3>
+            <p>Shipped Crypto Price Tracker alerts, PoGo rarity intelligence, and launched AWS Data Analytics Specialty prep with weekly public learning logs.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="certifications" id="credentials">
+      <div class="container">
+        <h2 class="section-title text-center">Credentials &amp; Continuous Learning</h2>
+        <div class="row">
+          <div class="col-lg-5 mb-4">
+            <div class="credential-card h-100">
+              <h3>In progress</h3>
+              <ul>
+                <li><strong>AWS Data Analytics Specialty</strong> · Self-study &amp; community labs · Target completion: Q4 2024</li>
               </ul>
-              <a href="https://public.flourish.studio/visualisation/9291169/" class="btn btn-primary">View Visualization</a>
             </div>
           </div>
-        </div>
-
-        <!-- Project 3 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Prize Scrapper for polla.cl</h4>
-              <p class="card-text">Python script to scrape prize information from the Chilean betting website polla.cl and update a Google Sheet.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">BeautifulSoup</span>
-                <span class="badge badge-tech">Google Sheets API</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Reverse engineered the prize tables, implemented resilient scraping, and orchestrated daily updates to stakeholders.</li>
-                <li><strong>Tech stack:</strong> Requests, BeautifulSoup, gspread, Docker cron container.</li>
-                <li><strong>Data volume:</strong> 80+ prize draws captured weekly with historical retention.</li>
-                <li><strong>Impact:</strong> Automated weekly prize updates, cutting manual effort by 4 hours and reducing reporting errors to zero.</li>
+          <div class="col-lg-7 mb-4">
+            <div class="credential-card h-100">
+              <h3>Selected certifications</h3>
+              <ul>
+                <li><strong><a href="https://www.udemy.com/certificate/UC-6516cd74-a25b-405d-962d-f3f6296db1c0/" target="_blank" rel="noopener">Automate the Boring Stuff with Python Programming</a></strong> · Udemy · Issued Dec 2022</li>
+                <li><strong><a href="https://www.credly.com/badges/7b6d0fbb-81b4-4b90-a07a-ad49506619cc/linked_in_profile" target="_blank" rel="noopener">Data Science Orientation</a></strong> · Coursera · Issued Oct 2022</li>
+                <li><strong><a href="https://graduation.udacity.com/confirm/KVWVKZFW" target="_blank" rel="noopener">AWS Machine Learning Foundations</a></strong> · Udacity · Issued Sep 2022</li>
+                <li><strong><a href="https://www.efset.org/cert/W91jYa" target="_blank" rel="noopener">EF SET English Certificate (C2)</a></strong> · EF · Issued Jun 2022</li>
+                <li><strong><a href="https://www.credly.com/badges/bfe5a0e2-b688-4300-be52-97d4ca8d6f6e/public_url" target="_blank" rel="noopener">Google Data Analytics</a></strong> · Coursera · Issued May 2022</li>
+                <li><strong><a href="https://www.udemy.com/certificate/UC-0d585a57-068e-4d51-9360-48283b103059/" target="_blank" rel="noopener">The Self-Taught Programmer</a></strong> · Udemy · Issued Mar 2022</li>
+                <li><strong><a href="https://www.udemy.com/certificate/UC-333e6d66-a544-475f-8cf7-747487ad2bc0/" target="_blank" rel="noopener">Business Intelligence Analyst</a></strong> · Udemy · Issued Oct 2021</li>
+                <li><strong><a href="https://www.credly.com/badges/01c42a0d-8939-41e4-8d26-73a796a95594/public_url" target="_blank" rel="noopener">SCRUM Foundation Professional</a></strong> · CertiProf · Issued Nov 2020 (renewed May 2023)</li>
+                <li><strong><a href="https://www.credly.com/badges/6396404d-ef8e-4388-b3d2-4f858afea8f9" target="_blank" rel="noopener">Cisco Certified Network Associate R&amp;S</a></strong> · Cisco · Issued Sep 2016</li>
               </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/polla#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Project README</a>
-              </div>
-              <a href="https://github.com/cortega26/polla" class="btn btn-primary">View Project on GitHub</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 4 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">PDF to Text Analyzer</h4>
-              <p class="card-text">Python script to download PDFs, convert them to text, and perform text analysis, including language identification and word frequency counting.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">NLTK</span>
-                <span class="badge badge-tech">AWS S3</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Designed the ingestion pipeline, normalized multilingual corpora, and packaged reusable CLI utilities.</li>
-                <li><strong>Tech stack:</strong> PyPDF2, langdetect, NLTK, AWS S3 for archival, GitHub Actions tests.</li>
-                <li><strong>Data volume:</strong> Processes batches of 500+ PDFs (approx. 1.2 GB) per run.</li>
-                <li><strong>Impact:</strong> Accelerated compliance reviews by surfacing key phrases 60% faster for the audit team.</li>
-              </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/PDF-Text-Analyzer#usage" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Usage Docs</a>
-              </div>
-              <a href="https://github.com/cortega26/PDF-Text-Analyzer" class="btn btn-primary">View Project on GitHub</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 5 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Fast Search API</h4>
-              <p class="card-text">Efficient FastAPI implementation for searching JSON data using various filters, including name, lastname, RUT (Chilean ID), and age.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">FastAPI</span>
-                <span class="badge badge-tech">Docker</span>
-                <span class="badge badge-tech">PostgreSQL</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Architected async endpoints, indexed search fields, and added observability dashboards.</li>
-                <li><strong>Tech stack:</strong> FastAPI, SQLAlchemy, PostgreSQL, Docker Compose, pytest.</li>
-                <li><strong>Data volume:</strong> Benchmarked against 2.5M citizen records with < 150 ms latency.</li>
-                <li><strong>Impact:</strong> Delivered a 6× faster lookup experience for customer-support teams handling fraud checks.</li>
-              </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/FastSearchAPI#api-reference" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">API Reference</a>
-              </div>
-              <a href="https://github.com/cortega26/FastSearchAPI" class="btn btn-primary">View Project on GitHub</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 6 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">File Extractor Pro</h4>
-              <p class="card-text">Desktop automation suite that inventories folders, applies compliance filters, and ships tamper-evident extraction reports in minutes.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">Tkinter</span>
-                <span class="badge badge-tech">AsyncIO</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Engineered the asynchronous extraction engine, hardened structured logging, and delivered a Tkinter command center for non-technical reviewers.</li>
-                <li><strong>Tech stack:</strong> Python 3.9+, Tkinter, asyncio, aiofiles, RotatingFileHandler audit logs.</li>
-                <li><strong>Data volume:</strong> Streams metadata with background workers so large directory trees process without freezing the UI.</li>
-                <li><strong>Impact:</strong> Equipped compliance and security reviewers to export evidence packs on demand without manual file triage.</li>
-              </ul>
-              <div class="project-links">
-              <a href="https://github.com/cortega26/File-Extractor-Pro#features" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Feature Overview</a>
-              </div>
-              <a href="https://github.com/cortega26/File-Extractor-Pro" class="btn btn-primary">View Project on GitHub</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 7 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Crypto Price Tracker</h4>
-              <p class="card-text">Real-time Binance monitor delivering configurable alerts (email, digest, threshold) for volatile assets.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">AsyncIO</span>
-                <span class="badge badge-tech">SMTP</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Architected polling, rate limiting, and notification layers for high-signal alerts.</li>
-                <li><strong>Tech stack:</strong> python-binance, APScheduler, Tkinter GUI, Docker for packaging.</li>
-                <li><strong>Impact:</strong> Keeps traders informed of ±5% swings without babysitting dashboards.</li>
-              </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/crypto-price-tracker#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Project README</a>
-              </div>
-              <a href="https://github.com/cortega26/crypto-price-tracker" class="btn btn-primary">View Project on GitHub</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 8 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">PoGo Rarity Intelligence</h4>
-              <p class="card-text">CLI + Streamlit suite ranking Pokémon GO spawns to optimize trades, evolutions, and community events.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">Streamlit</span>
-                <span class="badge badge-tech">Data Pipelines</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Contribution:</strong> Combined public catch data, rarity heuristics, and caching for instant queries.</li>
-                <li><strong>Tech stack:</strong> Pandas, requests, Streamlit, Poetry, pytest.</li>
-                <li><strong>Impact:</strong> Guides 2K+ monthly visitors on resource allocation, reducing guesswork in events.</li>
-              </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/PoGo#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Streamlit Demo</a>
-              </div>
-              <a href="https://github.com/cortega26/PoGo" class="btn btn-primary">View Project on GitHub</a>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-
-<!-- Math Lab Section -->
-  <section class="math-lab" id="math-lab">
-    <div class="container">
-      <h2 class="text-center">Math Lab &amp; Technical Repos</h2><br>
-      <p class="section-subtitle text-center">Evidence of continuous math, algorithms, and tooling practice—each repo includes READMEs, tests, and issue trackers documenting next experiments.</p>
-      <div class="row">
-        <div class="col-md-6 mb-4">
-          <div class="math-card h-100">
-            <h3>Algorithmic Challenges</h3>
-            <p>Google Foobar &amp; curated interview problems catalogued with solution trade-offs, pseudocode, and unit tests.</p>
-            <ul>
-              <li><a href="https://github.com/cortega26/Foobar" target="_blank" rel="noopener">Foobar</a>: Greedy, BFS, and number theory puzzles with runtime notes.</li>
-              <li><a href="https://github.com/cortega26/Challenges" target="_blank" rel="noopener">Challenges</a>: Job assessments annotated with assumptions and validation datasets.</li>
-            </ul>
+    <section class="portfolio" id="portfolio">
+      <div class="container">
+        <h2 class="section-title text-center">Featured Portfolio</h2>
+        <p class="section-subtitle text-center">Case studies spanning automation, APIs, and interactive analytics. Every repository includes setup guides, issue roadmaps, and metrics to replicate the results.</p>
+        <div class="row">
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Data Viz: GDP per Capita Growth (Americas)</h3>
+                <p class="card-text">Animated Flourish stories tracking GDP per capita PPP growth across 22 American countries since 1990.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">Flourish</span>
+                  <span class="badge badge-tech">ETL</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Contribution:</strong> Curated World Bank datasets, automated cleaning scripts, and produced executive-ready visuals.</li>
+                  <li><strong>Impact:</strong> Reduced manual chart prep by three hours per update for leadership briefings.</li>
+                </ul>
+                <a href="https://public.flourish.studio/visualisation/9177797/" class="btn btn-primary" target="_blank" rel="noopener">View Visualization</a>
+              </div>
+            </article>
           </div>
-        </div>
-        <div class="col-md-6 mb-4">
-          <div class="math-card h-100">
-            <h3>Quant &amp; Optimization Experiments</h3>
-            <p>Backtests, RUT validators, and forecasting notebooks demonstrating statistical rigor.</p>
-            <ul>
-              <li><a href="https://github.com/cortega26/Backtest-trading" target="_blank" rel="noopener">Backtest Trading</a>: Scenario analyses, Sharpe ratios, and position sizing templates.</li>
-              <li><a href="https://github.com/cortega26/rutificador" target="_blank" rel="noopener">Rutificador</a>: Production-ready Chilean tax ID validation with doctests and CI.</li>
-            </ul>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Data Viz: OECD Inflation Monitor</h3>
+                <p class="card-text">Cumulative inflation bar race covering 38 OECD members across three decades.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">Flourish</span>
+                  <span class="badge badge-tech">OECD API</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Contribution:</strong> Built extraction scripts against the OECD API and harmonized CPI indexes.</li>
+                  <li><strong>Impact:</strong> Equipped policy analysts to surface outliers within five minutes, accelerating newsletters.</li>
+                </ul>
+                <a href="https://public.flourish.studio/visualisation/9291169/" class="btn btn-primary" target="_blank" rel="noopener">View Visualization</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Prize Scraper for polla.cl</h3>
+                <p class="card-text">Automated data ingestion for the Chilean betting platform, publishing daily prize updates to Google Sheets.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">BeautifulSoup</span>
+                  <span class="badge badge-tech">Google Sheets API</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Contribution:</strong> Reverse engineered prize tables, implemented resilient scraping, and orchestrated stakeholder notifications.</li>
+                  <li><strong>Impact:</strong> Eliminated four hours of manual updates per week while preserving historical records.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/polla#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Project README</a>
+                </div>
+                <a href="https://github.com/cortega26/polla" class="btn btn-primary" target="_blank" rel="noopener">View on GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">PDF to Text Analyzer</h3>
+                <p class="card-text">CLI toolkit for downloading PDFs, extracting text, and detecting anomalies across multilingual corpora.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">NLTK</span>
+                  <span class="badge badge-tech">AWS S3</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Contribution:</strong> Designed the ingestion pipeline, normalized multilingual corpora, and packaged reusable utilities.</li>
+                  <li><strong>Impact:</strong> Surfaced key phrases 60% faster for compliance and audit reviewers.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/PDF-Text-Analyzer#usage" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Usage Docs</a>
+                </div>
+                <a href="https://github.com/cortega26/PDF-Text-Analyzer" class="btn btn-primary" target="_blank" rel="noopener">View on GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">FastSearchAPI</h3>
+                <p class="card-text">High-performance FastAPI service delivering millisecond searches across citizen records and fraud watchlists.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">FastAPI</span>
+                  <span class="badge badge-tech">Docker</span>
+                  <span class="badge badge-tech">PostgreSQL</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Contribution:</strong> Architected async endpoints, indexed search fields, and instrumented observability dashboards.</li>
+                  <li><strong>Impact:</strong> Delivered consistent &lt;150&nbsp;ms lookups for customer support fraud checks.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/FastSearchAPI#api-reference" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">API Reference</a>
+                </div>
+                <a href="https://github.com/cortega26/FastSearchAPI" class="btn btn-primary" target="_blank" rel="noopener">View on GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">File Extractor Pro</h3>
+                <p class="card-text">Desktop automation suite that inventories folders, applies compliance filters, and produces tamper-evident audit reports.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">Tkinter</span>
+                  <span class="badge badge-tech">AsyncIO</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Contribution:</strong> Engineered the asynchronous extraction engine and structured logging for non-technical reviewers.</li>
+                  <li><strong>Impact:</strong> Enabled teams to export evidence packs on demand without manual triage.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/File-Extractor-Pro#features" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Feature Overview</a>
+                </div>
+                <a href="https://github.com/cortega26/File-Extractor-Pro" class="btn btn-primary" target="_blank" rel="noopener">View on GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Crypto Price Tracker</h3>
+                <p class="card-text">Real-time Binance monitor delivering configurable alerts via email digests and threshold triggers.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">AsyncIO</span>
+                  <span class="badge badge-tech">SMTP</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Contribution:</strong> Architected polling, rate limiting, and notification layers for high-signal alerts.</li>
+                  <li><strong>Impact:</strong> Keeps traders informed of ±5% swings without monitoring dashboards around the clock.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/crypto-price-tracker#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Project README</a>
+                </div>
+                <a href="https://github.com/cortega26/crypto-price-tracker" class="btn btn-primary" target="_blank" rel="noopener">View on GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">PoGo Rarity Intelligence</h3>
+                <p class="card-text">CLI and Streamlit experience ranking Pokémon GO spawns to optimize trades, evolutions, and community days.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">Streamlit</span>
+                  <span class="badge badge-tech">Data Pipelines</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Contribution:</strong> Combined public catch data, rarity heuristics, and caching for instant queries.</li>
+                  <li><strong>Impact:</strong> Guides 2K+ monthly visitors on where to invest in-game resources.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/PoGo#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Streamlit Demo</a>
+                </div>
+                <a href="https://github.com/cortega26/PoGo" class="btn btn-primary" target="_blank" rel="noopener">View on GitHub</a>
+              </div>
+            </article>
           </div>
         </div>
       </div>
-      <p class="math-lab-footer text-center">Browse the <a href="https://github.com/cortega26?tab=repositories" target="_blank" rel="noopener">full GitHub profile</a> for additional notebooks, trading bots, and civic-tech experiments currently in development.</p>
-    </div>
-  </section>
+    </section>
 
-
-<!-- Contact Section -->
-  <section class="contact" id="contact">
-    <div class="container">
-      <h2 class="text-center">Contact</h2><br>
-      <div class="row">
-        <div class="col-lg-5 mb-4">
-          <div class="contact-summary h-100">
-            <p>Let's build resilient data products together. Share a short brief or invite me to a discovery call—I'll respond with next steps and resources tailored to your roadmap.</p>
-            <div class="contact-actions">
-              <a class="btn btn-cta contact-btn" href="mailto:carlosortega77@gmail.com?subject=Resume%20Request" rel="noopener">Request Résumé</a>
-              <a class="btn btn-outline-light contact-btn" href="https://www.linkedin.com/in/cortega26" target="_blank" rel="noopener">Connect on LinkedIn</a>
-              <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Schedule via Calendly</a>
-            </div>
-            <p class="contact-response">Preferred response window: within 48 business hours, with calls available Tuesday–Thursday, 9:00–15:00 CLT.</p>
-            <p class="contact-response">Need a faster answer? Email me directly and I'll prioritize urgent production issues.</p>
+    <section class="math-lab" id="math-lab">
+      <div class="container">
+        <h2 class="section-title text-center">Math Lab &amp; Technical Repositories</h2>
+        <p class="section-subtitle text-center">Proof of ongoing math, algorithms, and tooling practice—each repo includes READMEs, tests, and issue trackers with next experiments.</p>
+        <div class="row">
+          <div class="col-md-6 mb-4">
+            <article class="math-card h-100">
+              <h3>Algorithmic Challenges</h3>
+              <p>Google Foobar and curated interview problems catalogued with solution trade-offs, pseudocode, and unit tests.</p>
+              <ul>
+                <li><a href="https://github.com/cortega26/Foobar" target="_blank" rel="noopener">Foobar</a>: Greedy, BFS, and number theory puzzles with runtime analysis.</li>
+                <li><a href="https://github.com/cortega26/Challenges" target="_blank" rel="noopener">Challenges</a>: Job assessments annotated with assumptions and validation datasets.</li>
+              </ul>
+            </article>
+          </div>
+          <div class="col-md-6 mb-4">
+            <article class="math-card h-100">
+              <h3>Quant &amp; Optimization Experiments</h3>
+              <p>Backtests, RUT validators, and forecasting notebooks demonstrating statistical rigor.</p>
+              <ul>
+                <li><a href="https://github.com/cortega26/Backtest-trading" target="_blank" rel="noopener">Backtest Trading</a>: Scenario analysis, Sharpe ratios, and position sizing templates.</li>
+                <li><a href="https://github.com/cortega26/rutificador" target="_blank" rel="noopener">Rutificador</a>: Production-ready Chilean tax ID validation with doctests and CI.</li>
+              </ul>
+            </article>
           </div>
         </div>
-        <div class="col-lg-7 mb-4">
-          <form class="contact-form" id="contact-form">
-            <div class="form-group">
-              <label class="sr-only" for="name">Your Name</label>
-              <input type="text" class="form-control" id="name" name="name" placeholder="Your Name" required>
-            </div>
-            <div class="form-group">
-              <label class="sr-only" for="email">Your Email</label>
-              <input type="email" class="form-control" id="email" name="email" placeholder="Your Email" required>
-            </div>
-            <div class="form-group">
-              <label class="sr-only" for="subject">Subject</label>
-              <input type="text" class="form-control" id="subject" name="subject" placeholder="Project or Role" required>
-            </div>
-            <div class="form-group">
-              <label class="sr-only" for="message">Message</label>
-              <textarea class="form-control" id="message" name="message" rows="5" placeholder="Share context, timelines, and goals" required></textarea>
-            </div>
-            <button type="submit" class="btn btn-primary contact-submit">Open Email Draft</button>
-          </form>
-        </div>
+        <p class="math-lab-footer text-center">Explore the <a href="https://github.com/cortega26?tab=repositories" target="_blank" rel="noopener">full GitHub profile</a> for additional notebooks, trading bots, and civic-tech experiments.</p>
       </div>
+    </section>
 
-
-      <!-- Social Networks -->
-      <div class="container text-center">
-        <div class="social-media-container">
-          <div class="social-media-buttons btn-group">
-            <a href="https://github.com/cortega26" class="btn btn-dark"><i class="fab fa-github"></i></a>
-            <a href="https://www.linkedin.com/in/cortega26" class="btn btn-primary"><i class="fab fa-linkedin"></i></a>
-            <a href="https://twitter.com/cortega26" class="btn btn-dark"><i class="fab fa-twitter"></i></a>
-            <a href="https://wa.me/56951118901" class="btn btn-success"><i class="fab fa-whatsapp"></i></a>
-            <a href="mailto:carlosortega77@gmail.com" class="btn btn-dark"><i class="far fa-envelope"></i></a>
+    <section class="contact" id="contact">
+      <div class="container">
+        <h2 class="section-title text-center">Partner With Me</h2>
+        <p class="section-subtitle text-center">Share context, timelines, and desired outcomes—I will respond with next steps and tailored resources within two business days.</p>
+        <div class="row">
+          <div class="col-lg-5 mb-4">
+            <div class="contact-summary h-100">
+              <p>Let’s design resilient data products together. Whether you need an interim analytics lead or targeted automation, I bring structured discovery, transparent delivery, and executive-ready narratives.</p>
+              <div class="contact-actions">
+                <a class="btn btn-cta contact-btn" href="mailto:carlosortega77@gmail.com?subject=Resume%20Request" rel="noopener">Request Résumé</a>
+                <a class="btn btn-outline-light contact-btn" href="https://www.linkedin.com/in/cortega26" target="_blank" rel="noopener">Connect on LinkedIn</a>
+                <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Schedule via Calendly</a>
+              </div>
+              <p class="contact-response">Preferred response window: within 48 business hours · Calls available Tuesday–Thursday, 09:00–15:00 CLT.</p>
+              <p class="contact-response">Need an urgent escalation? Email me directly and I will prioritize production-critical work.</p>
+            </div>
+          </div>
+          <div class="col-lg-7 mb-4">
+            <form class="contact-form" id="contact-form">
+              <div class="form-group">
+                <label class="sr-only" for="name">Your Name</label>
+                <input type="text" class="form-control" id="name" name="name" placeholder="Your Name" required>
+              </div>
+              <div class="form-group">
+                <label class="sr-only" for="email">Your Email</label>
+                <input type="email" class="form-control" id="email" name="email" placeholder="Your Email" required>
+              </div>
+              <div class="form-group">
+                <label class="sr-only" for="subject">Project or Role</label>
+                <input type="text" class="form-control" id="subject" name="subject" placeholder="Project or Role" required>
+              </div>
+              <div class="form-group">
+                <label class="sr-only" for="message">Message</label>
+                <textarea class="form-control" id="message" name="message" rows="5" placeholder="Share context, timelines, and goals" required></textarea>
+              </div>
+              <button type="submit" class="btn btn-primary contact-submit">Open Email Draft</button>
+            </form>
+          </div>
+        </div>
+        <div class="social-media-container text-center">
+          <div class="social-media-buttons btn-group" role="group" aria-label="Social media links">
+            <a href="https://github.com/cortega26" class="btn btn-dark" target="_blank" rel="noopener" aria-label="GitHub"><i class="fab fa-github"></i></a>
+            <a href="https://www.linkedin.com/in/cortega26" class="btn btn-primary" target="_blank" rel="noopener" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+            <a href="https://twitter.com/cortega26" class="btn btn-dark" target="_blank" rel="noopener" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+            <a href="https://wa.me/56951118901" class="btn btn-success" target="_blank" rel="noopener" aria-label="WhatsApp"><i class="fab fa-whatsapp"></i></a>
+            <a href="mailto:carlosortega77@gmail.com" class="btn btn-dark" aria-label="Email"><i class="far fa-envelope"></i></a>
           </div>
         </div>
       </div>
-    </div>
-  </section>
-
+    </section>
+  </main>
 
   <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
   <script src="./english/script.js"></script>
-
 </body>
-
 </html>

--- a/english/english/script.js
+++ b/english/english/script.js
@@ -1,110 +1,53 @@
-
-// For example, smooth scrolling to sections on clicking nav links
-
 $(document).ready(function() {
-  $(".nav-link").on("click", function(event) {
-    event.preventDefault();
-    const target = $(this).attr("href");
-    $("html, body").animate({
-      scrollTop: $(target).offset().top
-    }, 800);
+  $('a[href^="#"]').on('click', function(event) {
+    const target = $(this.getAttribute('href'));
+    if (target.length) {
+      event.preventDefault();
+      $('html, body').animate({
+        scrollTop: target.offset().top
+      }, 800);
+    }
   });
 });
 
-
-/* // Define an array of engaging messages
-const messages = [
-    "It's about 3.1416 \nThis is not a Sandra Bullock movie",
-    "Congratulations! You've unlocked the power of π. But beware, secrets come with a price...",
-    "Spiders crawl, secrets beckon. How deep will you venture into the digital abyss?",
-    "The cosmos whisper, the code calls. A universe of mysteries awaits...",
-    "A portal to the unknown has been opened. The ancient symbol of π reveals hidden truths...",
-    "Illuminating the shadows of the digital realm, you've embarked on a thrilling quest...",
-    "Binary whispers echo through the cyberspace. The enigma of π holds untold wonders...",
-    "Decoding the language of numbers, you've awakened a dormant power within...",
-    "The world of possibilities unfolds before you. The journey has just begun...",
-  ];
-  
-  // Initialize click count
-  let clickCount = 0;
-  
-  function showPiMessage() {
-    // Check if all messages have been displayed
-    if (clickCount === messages.length) {
-      // Last message with the call to action
-      const finalMessage = "I hope you had enough fun, now it's time to hire me. Let's create something extraordinary together!";
-      alert(finalMessage);
-    } else {
-      // Get the current message based on the click count
-      const message = messages[clickCount % messages.length];
-  
-      // Increment click count for the next click
-      clickCount++;
-  
-      alert(message);
-    }
-  } */
-
-
-// Define messages for English
 const messagesEn = [
-  "It's about 3.1416 \nThis is not a Sandra Bullock movie",
-    "Congratulations! You've unlocked the power of π. But beware, secrets come with a price...",
-    "Spiders crawl, secrets beckon. How deep will you venture into the digital abyss?",
-    "The cosmos whisper, the code calls. A universe of mysteries awaits...",
-    "A portal to the unknown has been opened. The ancient symbol of π reveals hidden truths...",
-    "Illuminating the shadows of the digital realm, you've embarked on a thrilling quest...",
-    "Binary whispers echo through the cyberspace. The enigma of π holds untold wonders...",
-    "Decoding the language of numbers, you've awakened a dormant power within...",
-    "The world of possibilities unfolds before you. The journey has just begun...",
+  "Analytics should feel calm and reliable—curious how I returned 420 hours to analysts?",
+  "Bilingual partner here. Need a guide through compliance, fraud, or growth dashboards?",
+  "FastAPI, SQL, and storytelling—pick two and I'll add the third.",
+  "Serious about automation readiness? Let's co-design your next delivery playbook.",
+  "Looking for algorithmic proof? My math lab is just a few scrolls away."
 ];
 
-// Define messages for Spanish
 const messagesEs = [
-  "¡Es sobre 3.1416! \nEsto no es una película de Sandra Bullock",
-  "¡Felicidades! Has desbloqueado el poder de π. Pero cuidado, los secretos tienen un precio...",
-  // Add more Spanish messages here
+  "La analítica debe sentirse segura y predecible—¿quieres saber cómo devolví 420 horas a los analistas?",
+  "Compañero bilingüe disponible. ¿Necesitas guía en cumplimiento, fraude o dashboards de crecimiento?",
+  "FastAPI, SQL y storytelling: elige dos y yo sumo el tercero.",
+  "¿Listo para automatizar con solidez? Diseñemos juntos tu próximo playbook de entrega.",
+  "¿Buscas evidencia algorítmica? Mi laboratorio matemático está unas secciones más abajo."
 ];
 
-// Initialize click count
 let clickCount = 0;
 
 function showPiMessage() {
-  // Check the value of the lang attribute
-  const langAttribute = document.documentElement.getAttribute("lang");
-  
-  // Determine the messages based on the language
-  let messages;
-  if (langAttribute && langAttribute.startsWith("es")) {
-      messages = messagesEs;
-  } else {
-      messages = messagesEn;
+  const langAttribute = document.documentElement.getAttribute('lang');
+  const isSpanish = langAttribute && langAttribute.startsWith('es');
+  const messages = isSpanish ? messagesEs : messagesEn;
+
+  if (clickCount >= messages.length) {
+    const finalMessage = isSpanish
+      ? '¿Listo para conversar? Agenda una llamada de descubrimiento y avancemos.'
+      : 'Ready to talk? Book a discovery call and let’s move forward.';
+    alert(finalMessage);
+    clickCount = 0;
+    return;
   }
 
-  // Check if all messages have been displayed
-  if (clickCount === messages.length) {
-      // Last message with the call to action
-      const finalMessage = "I hope you had enough fun, now it's time to hire me. Let's create something extraordinary together!";
-      alert(finalMessage);
-  } else {
-      // Get the current message based on the click count
-      const message = messages[clickCount % messages.length];
-
-      // Increment click count for the next click
-      clickCount++;
-
-      alert(message);
-  }
+  alert(messages[clickCount]);
+  clickCount += 1;
 }
 
-
-
-
-
-
-
 function sendEmailFallback(event) {
-  const contactForm = document.getElementById("contact-form");
+  const contactForm = document.getElementById('contact-form');
 
   if (!contactForm) {
     return;
@@ -112,20 +55,27 @@ function sendEmailFallback(event) {
 
   event.preventDefault();
 
-  const name = contactForm.elements["name"].value.trim();
-  const email = contactForm.elements["email"].value.trim();
-  const subject = contactForm.elements["subject"].value.trim();
-  const message = contactForm.elements["message"].value.trim();
+  const langAttribute = document.documentElement.getAttribute('lang');
+  const isSpanish = langAttribute && langAttribute.startsWith('es');
 
-  const composedSubject = subject ? `${subject} — ${name || "Portfolio Inquiry"}` : `Portfolio Inquiry from ${name || "Website Visitor"}`;
+  const name = contactForm.elements['name'].value.trim();
+  const email = contactForm.elements['email'].value.trim();
+  const subject = contactForm.elements['subject'].value.trim();
+  const message = contactForm.elements['message'].value.trim();
+
+  const fallbackSubject = isSpanish ? 'Consulta de portafolio' : 'Portfolio Inquiry';
+  const composedSubject = subject
+    ? `${subject} — ${name || fallbackSubject}`
+    : `${fallbackSubject} ${isSpanish ? 'de' : 'from'} ${name || (isSpanish ? 'Visita al sitio web' : 'Website Visitor')}`;
+
   const bodyLines = [
-    `Name: ${name || "Not provided"}`,
-    `Email: ${email || "Not provided"}`,
-    "",
-    message || "",
+    `${isSpanish ? 'Nombre' : 'Name'}: ${name || (isSpanish ? 'No proporcionado' : 'Not provided')}`,
+    `${isSpanish ? 'Correo' : 'Email'}: ${email || (isSpanish ? 'No proporcionado' : 'Not provided')}`,
+    '',
+    message || ''
   ];
 
-  const mailtoLink = `mailto:carlosortega77@gmail.com?subject=${encodeURIComponent(composedSubject)}&body=${encodeURIComponent(bodyLines.join("\n"))}`;
+  const mailtoLink = `mailto:carlosortega77@gmail.com?subject=${encodeURIComponent(composedSubject)}&body=${encodeURIComponent(bodyLines.join('\n'))}`;
 
   window.location.href = mailtoLink;
 
@@ -133,13 +83,15 @@ function sendEmailFallback(event) {
     contactForm.reset();
   }, 300);
 
-  alert("Your message details have been prepared in your email client. Please review and send it to complete your outreach.");
+  alert(isSpanish
+    ? 'Tu mensaje está listo en tu cliente de correo. Revísalo y envíalo para completar el contacto.'
+    : 'Your message draft is ready in your email client. Review and send it to complete your outreach.');
 }
 
-document.addEventListener("DOMContentLoaded", function() {
-  const contactForm = document.getElementById("contact-form");
+document.addEventListener('DOMContentLoaded', function() {
+  const contactForm = document.getElementById('contact-form');
 
   if (contactForm) {
-    contactForm.addEventListener("submit", sendEmailFallback);
+    contactForm.addEventListener('submit', sendEmailFallback);
   }
 });

--- a/english/english/style.css
+++ b/english/english/style.css
@@ -1,339 +1,462 @@
-body {
-    font-family: 'Courier New', monospace;
-    background-color: black;
-    color: white;
-  }
-  
-  .navbar {
-    background-color: black !important;
-    font-family: Arial, Helvetica, sans-serif;
-  }
-  
-  .navbar-brand {
-    font-size: 18px;
-  }
-
-  .navbar-nav {
-    font-size: 14px;
-  }
-
-  .landing {
-    background: linear-gradient(to bottom, black, #333);
-    padding: 80px 0;
-  }
-
-.hero-cta {
-  margin-top: 24px;
+:root {
+  --bg: #0b0d17;
+  --surface: #11182a;
+  --surface-alt: #141d33;
+  --surface-light: #18233a;
+  --border: #1f2a40;
+  --text: #f5f7ff;
+  --muted: #c3cadc;
+  --accent: #5b8def;
+  --accent-soft: rgba(91, 141, 239, 0.18);
+  --success: #41b883;
+  --font-body: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  --font-display: 'Playfair Display', 'Times New Roman', serif;
 }
 
-.hero-cta .btn {
-  font-weight: 600;
-  padding: 12px 28px;
-  border-radius: 50px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding-top: 84px;
+  line-height: 1.7;
+}
+
+a {
+  color: var(--accent);
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  color: #86aef7;
+  text-decoration: none;
+}
+
+.navbar {
+  background-color: rgba(8, 10, 18, 0.95) !important;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  letter-spacing: 0.02em;
+}
+
+.navbar-brand {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+}
+
+.navbar-nav .nav-link {
+  font-weight: 500;
+  color: var(--muted) !important;
+  padding: 0.75rem 1rem;
+}
+
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link:focus {
+  color: var(--text) !important;
+}
+
+main section {
+  padding: 96px 0;
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.section-subtitle,
+.section-intro {
+  max-width: 780px;
+  margin: 0 auto 2.5rem auto;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.hero-layout {
+  row-gap: 40px;
+}
+
+.landing {
+  background: radial-gradient(circle at top left, rgba(91, 141, 239, 0.12), transparent 45%),
+              radial-gradient(circle at bottom right, rgba(65, 184, 131, 0.18), transparent 55%),
+              linear-gradient(140deg, #090b13 0%, #0f1626 60%, #0b0d17 100%);
+  padding: 140px 0 120px;
+}
+
+.hero-eyebrow {
+  display: inline-block;
+  font-size: 0.85rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+.hero-lede {
+  font-size: 1.15rem;
+  color: var(--muted);
+  margin-top: 18px;
 }
 
 .hero-highlights {
   list-style: none;
   padding: 0;
-  margin: 24px auto 0;
-  max-width: 640px;
-  text-align: left;
+  margin: 28px 0 36px;
 }
 
 .hero-highlights li {
-  font-size: 1.05rem;
-  line-height: 1.6;
-  margin-bottom: 12px;
-  padding-left: 28px;
   position: relative;
+  padding-left: 28px;
+  margin-bottom: 14px;
+  font-size: 1.02rem;
 }
 
 .hero-highlights li::before {
-  content: '\2022';
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
   position: absolute;
   left: 0;
-  top: 0;
-  color: #00d1ff;
-  font-size: 1.3rem;
-  line-height: 1.6;
+  top: 10px;
+  box-shadow: 0 0 0 6px var(--accent-soft);
 }
 
-.hero-meta {
-  list-style: none;
-  margin: 28px auto 0;
-  padding: 0;
-  max-width: 820px;
-  display: grid;
-  gap: 12px;
+.hero-cta .btn {
+  font-weight: 600;
+  padding: 14px 30px;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.hero-meta li {
-  background: rgba(0, 0, 0, 0.6);
-  border: 1px solid #222;
-  border-radius: 12px;
-  padding: 14px 18px;
-  font-size: 0.95rem;
-  line-height: 1.6;
+.btn-cta {
+  background: var(--accent);
+  border: 1px solid transparent;
+  color: #05060a;
+  box-shadow: 0 18px 40px rgba(91, 141, 239, 0.28);
 }
 
-.hero-cta .btn-primary {
-  background-color: #007bff;
-  border-color: #007bff;
-}
-
-.hero-cta .btn-cta {
-  background-color: #00d1ff;
-  border-color: #00d1ff;
-  color: #000;
-  box-shadow: 0 8px 18px rgba(0, 209, 255, 0.3);
-}
-
-.hero-cta .btn-cta:hover {
-  background-color: #1ae0ff;
-  border-color: #1ae0ff;
-  color: #000;
-}
-
-.hero-cta .btn-primary:hover,
-.hero-cta .btn-outline-light:hover {
+.btn-cta:hover,
+.btn-cta:focus {
   transform: translateY(-2px);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+  background: #779ef5;
 }
 
-.hero-cta .btn-outline-light {
-  color: #fff;
-  border-color: #f8f9fa;
+.btn-outline-light:hover,
+.btn-outline-light:focus,
+.btn-primary:hover,
+.btn-primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
 }
 
-.hero-cta .btn-outline-light:hover {
-  background-color: #f8f9fa;
-  color: #000;
-}
-
-@media (max-width: 576px) {
-  .hero-highlights {
-    margin-top: 20px;
-    padding: 0 16px;
-  }
-
-  .hero-highlights li {
-    font-size: 1rem;
-  }
-
-  .hero-meta {
-    padding: 0 16px;
-  }
-
-  .hero-cta .btn {
-    width: 100%;
-  }
-}
-
-  .profile-image {
-    width: 360px;
-    height: 360px;
-    border-radius: 50%;
-    margin-top: 26px;
-    margin-bottom: 26px;
-    border: 5px solid white;
-  }
-  
-h2 {
-  font-family: 'Arial', sans-serif; /* Choose a font that suits your preference */
-  font-size: 36px; /* Adjust the size as needed */
-  font-weight: bold;
-}
-
-.about p {
-  font-size: 18px; /* Adjust the size as needed */
-  line-height: 1.6; /* Add line height for better readability */
-  margin-bottom: 26px;
-}
-
-.about-intro {
-  max-width: 720px;
-  margin-left: auto;
-  margin-right: auto;
+.hero-figure {
+  background: rgba(10, 13, 22, 0.8);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 28px;
   text-align: center;
+  margin-bottom: 24px;
 }
 
+.profile-image {
+  width: 100%;
+  max-width: 320px;
+  border-radius: 24px;
+  border: 4px solid rgba(255, 255, 255, 0.12);
+  margin-bottom: 18px;
+}
+
+.hero-figure figcaption {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero-meta-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.hero-meta-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 20px 22px;
+}
+
+.hero-meta-card h3 {
+  font-size: 1.05rem;
+  margin-bottom: 6px;
+}
+
+.hero-meta-card p {
+  color: var(--muted);
+  margin-bottom: 0;
+}
+
+.about {
+  background: #0c121f;
+}
 
 .about-grid {
   display: grid;
   gap: 24px;
-  margin-top: 40px;
+  margin-top: 48px;
 }
 
 .about-card {
-  background-color: rgba(17, 17, 17, 0.9);
-  border: 1px solid #222;
-  border-radius: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
   padding: 28px;
+  min-height: 100%;
 }
 
 .about-card h3 {
-  font-size: 1.4rem;
+  font-size: 1.25rem;
   margin-bottom: 16px;
 }
 
-.about-highlights {
+.about-list {
   list-style: none;
-  margin: 0;
   padding: 0;
+  margin: 0;
 }
 
-.about-highlights li {
-  font-size: 1.02rem;
-  line-height: 1.6;
-  margin-bottom: 14px;
-  padding-left: 24px;
+.about-list li {
   position: relative;
+  padding-left: 22px;
+  margin-bottom: 12px;
+  color: var(--muted);
 }
 
-.about-highlights li::before {
+.about-list li::before {
   content: '\2022';
+  color: var(--accent);
   position: absolute;
   left: 0;
   top: 0;
-  color: #00d1ff;
-  font-size: 1.2rem;
-  line-height: 1.6;
 }
 
-.about,
-  .portfolio,
-  .contact {
-    padding: 100px 0;
-  }
-
-.section-subtitle {
-  max-width: 780px;
-  margin: 0 auto 42px;
-  font-size: 1.05rem;
-  line-height: 1.7;
-  color: #d0d0d0;
+.capabilities {
+  background: linear-gradient(160deg, #0c121f 0%, #0b0d17 60%, #0c111c 100%);
 }
 
-.strengths {
-  background-color: #0a0a0a;
-  padding: 100px 0;
-}
-
-.strength-card {
-  background-color: rgba(17, 17, 17, 0.95);
-  border: 1px solid #222;
-  border-radius: 16px;
+.capability-card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 20px;
   padding: 28px;
   display: flex;
   flex-direction: column;
 }
 
-.strength-card h3 {
-  font-size: 1.3rem;
-  margin-bottom: 14px;
+.capability-card h3 {
+  font-size: 1.25rem;
+  margin-bottom: 12px;
 }
 
-.strength-card p {
-  font-size: 1rem;
-  line-height: 1.6;
+.capability-card p {
+  color: var(--muted);
   margin-bottom: 16px;
 }
 
-.strength-card ul {
+.capability-card ul {
   list-style: none;
-  padding: 0;
   margin: 0;
+  padding: 0;
 }
 
-.strength-card li {
-  font-size: 0.95rem;
-  line-height: 1.6;
-  margin-bottom: 10px;
-  padding-left: 20px;
+.capability-card li {
+  color: var(--muted);
   position: relative;
+  padding-left: 20px;
+  margin-bottom: 10px;
 }
 
-.strength-card li::before {
-  content: '\2022';
+.capability-card li::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
   position: absolute;
   left: 0;
-  top: 0;
-  color: #1ae0ff;
-  font-size: 1.1rem;
-  line-height: 1.6;
+  top: 12px;
 }
 
-.roadmap {
-  padding: 100px 0;
+.experience {
+  background: #0b0f19;
 }
 
 .roadmap-timeline {
   display: grid;
   gap: 20px;
-  margin-top: 40px;
+  margin-top: 48px;
 }
 
 .roadmap-item {
-  border-left: 3px solid #00d1ff;
-  padding: 20px 24px;
-  background: rgba(17, 17, 17, 0.9);
-  border-radius: 12px;
   position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 24px 28px 24px 40px;
 }
 
 .roadmap-item::before {
   content: '';
   position: absolute;
-  left: -9px;
-  top: 24px;
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  background: #00d1ff;
-  box-shadow: 0 0 12px rgba(0, 209, 255, 0.5);
+  background: var(--accent);
+  box-shadow: 0 0 0 8px var(--accent-soft);
+  left: 18px;
+  top: 32px;
 }
 
 .roadmap-date {
   font-size: 0.85rem;
-  letter-spacing: 1.2px;
+  letter-spacing: 0.15em;
   text-transform: uppercase;
-  color: #1ae0ff;
+  color: var(--muted);
 }
 
 .roadmap-item h3 {
-  margin-top: 10px;
-  font-size: 1.25rem;
+  margin-top: 12px;
+  font-size: 1.2rem;
 }
 
 .roadmap-item p {
-  margin-top: 12px;
-  font-size: 1rem;
-  line-height: 1.7;
-  color: #d8d8d8;
+  color: var(--muted);
+  margin-bottom: 0;
 }
 
-.math-lab {
-  background-color: #0a0a0a;
-  padding: 100px 0;
+.certifications {
+  background: #0f1626;
 }
 
-.math-card {
-  background: rgba(17, 17, 17, 0.95);
-  border: 1px solid #222;
-  border-radius: 16px;
-  padding: 28px;
+.credential-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  padding: 30px;
+  height: 100%;
 }
 
-.math-card h3 {
-  font-size: 1.3rem;
+.credential-card h3 {
+  font-size: 1.2rem;
+  margin-bottom: 18px;
+}
+
+.credential-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.credential-card li {
+  color: var(--muted);
+  margin-bottom: 14px;
+  padding-left: 20px;
+  position: relative;
+}
+
+.credential-card li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--accent);
+}
+
+.portfolio {
+  background: #0c121f;
+}
+
+.custom-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  margin-bottom: 28px;
+}
+
+.custom-card .card-title {
+  font-size: 1.25rem;
+  margin-bottom: 12px;
+}
+
+.custom-card .card-text {
+  color: var(--muted);
+}
+
+.project-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 18px 0;
+}
+
+.badge-tech {
+  background: rgba(91, 141, 239, 0.18);
+  color: var(--accent);
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.project-details {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px;
+}
+
+.project-details li {
+  color: var(--muted);
+  margin-bottom: 10px;
+  padding-left: 20px;
+  position: relative;
+}
+
+.project-details li::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  position: absolute;
+  left: 0;
+  top: 11px;
+}
+
+.project-links {
   margin-bottom: 14px;
 }
 
-.math-card p {
-  font-size: 1rem;
-  line-height: 1.6;
-  margin-bottom: 18px;
+.math-lab {
+  background: #0b0f19;
+}
+
+.math-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 28px;
+  height: 100%;
+}
+
+.math-card p,
+.math-card li {
+  color: var(--muted);
 }
 
 .math-card ul {
@@ -344,8 +467,6 @@ h2 {
 
 .math-card li {
   margin-bottom: 12px;
-  font-size: 0.95rem;
-  line-height: 1.6;
   padding-left: 20px;
   position: relative;
 }
@@ -355,244 +476,124 @@ h2 {
   position: absolute;
   left: 0;
   top: 0;
-  color: #1ae0ff;
-  font-size: 1.1rem;
-  line-height: 1.6;
-}
-
-.math-card a {
-  color: #1ae0ff;
-  text-decoration: underline;
-}
-
-.math-card a:hover {
-  color: #7df2ff;
+  color: var(--accent);
 }
 
 .math-lab-footer {
-  margin-top: 24px;
-  font-size: 0.95rem;
+  color: var(--muted);
+  margin-top: 28px;
 }
 
-  #pi {
-    font-family: Times, serif, Arial, Helvetica, sans-serif, serif;
-  }
+.contact {
+  background: linear-gradient(160deg, #0a0f1b 0%, #0b141f 60%, #09101a 100%);
+}
 
 .contact-summary {
-  background-color: #111;
-  border: 1px solid #222;
-  border-radius: 16px;
-  padding: 28px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  padding: 32px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  height: 100%;
+  gap: 18px;
 }
 
 .contact-actions {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin: 20px 0;
-}
-
-.contact .btn {
-  font-weight: 600;
-  border-radius: 999px;
 }
 
 .contact-btn {
   width: 100%;
-  text-align: center;
 }
 
 .contact-response {
+  color: var(--muted);
   font-size: 0.95rem;
-  line-height: 1.6;
-  margin-bottom: 8px;
-  color: #d0d0d0;
-}
-
-.contact-submit {
-  padding: 12px 28px;
-  width: 100%;
-}
-
-.contact-form .form-group {
-  margin-bottom: 18px;
+  margin: 0;
 }
 
 .contact-form .form-control {
-  background-color: #0a0a0a;
-  border-color: #333;
-  color: #fff;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 14px;
+  padding: 14px 16px;
 }
 
 .contact-form .form-control:focus {
-  box-shadow: 0 0 0 0.2rem rgba(0, 209, 255, 0.25);
-  border-color: #00d1ff;
+  background: var(--surface-light);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 0.25rem rgba(91, 141, 239, 0.2);
 }
 
-@media (min-width: 576px) {
-  .contact-actions {
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-
-  .contact-btn {
-    flex: 1 1 180px;
-  }
+.contact-submit {
+  width: 100%;
+  padding: 14px 28px;
+  border-radius: 14px;
 }
 
-@media (max-width: 575.98px) {
-  .contact-summary {
-    padding: 24px 20px;
-  }
+.social-media-container {
+  margin-top: 32px;
 }
 
-.social-media-buttons a.btn.btn-dark,
-.social-media-buttons a.btn.btn-primary,
-.social-media-buttons a.btn.btn-success {
+.social-media-buttons a {
   border-radius: 50% !important;
-  width: 40px; /* Set a fixed width */
-  height: 40px; /* Set a fixed height */
-  margin-left: 5px;
-  margin-right: 5px;
-}
-
-.social-media-buttons .btn-dark,
-.social-media-buttons a.btn.btn-primary,
-.social-media-buttons .btn-success {
-  display: flex;
-  justify-content: center;
+  width: 46px;
+  height: 46px;
+  display: inline-flex;
   align-items: center;
-}
-
-.social-media-buttons .btn-dark i,
-.social-media-buttons a.btn.btn-primary,
-.social-media-buttons .btn-success i {
-  font-size: 24px;
-}
-
-
-.custom-card {
-  background-color: black;
-  color: white;
-  border: 1px solid #333;
-}
-
-.project-badges {
-  display: flex;
   justify-content: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 12px 0 6px;
+  margin: 0 6px;
+  transition: transform 0.2s ease;
 }
 
-.badge-tech {
-  background-color: #1ae0ff;
-  color: #000;
-  font-weight: 600;
-  border-radius: 999px;
-  padding: 6px 14px;
-  font-size: 0.75rem;
-  letter-spacing: 0.4px;
-}
-
-.card-body .project-details {
-  list-style: none;
-  padding: 0;
-  margin: 12px 0 16px;
-}
-
-.card-body .project-details li {
-  text-align: left;
-  font-size: 0.95rem;
-  line-height: 1.6;
-  margin-bottom: 8px;
-  position: relative;
-  padding-left: 20px;
-}
-
-.card-body .project-details li::before {
-  content: '\2022';
-  position: absolute;
-  left: 0;
-  top: 0;
-  color: #00d1ff;
-  font-size: 1.1rem;
-  line-height: 1.6;
-}
-
-.project-links {
-  margin-bottom: 12px;
-}
-
-.project-links .btn {
-  margin: 0 4px 8px;
-}
-
-.math-card ul,
-.strength-card ul {
-  margin-bottom: 0;
-}
-
-
-.certifications {
-  background-color: #333;
-  color: white;
-  padding: 100px 0;
-}
-
-.certifications h2 {
-  font-size: 36px;
-  font-weight: bold;
-  text-align: center;
-}
-
-.certifications ul {
-  list-style: none;
-  padding: 0;
-}
-
-.certifications li {
-  margin-bottom: 20px;
-  border: 1px solid white;
-  padding: 20px;
-}
-
-.certifications li strong {
-  font-size: 20px;
-  display: block;
-}
-
-.certifications li span {
-  display: block;
-  margin-top: 8px;
-  font-size: 14px;
-}
-
-.certifications li a {
-  color: white;
-  text-decoration: none;
-}
-
-.certifications li a:hover {
-  text-decoration: underline;
+.social-media-buttons a:hover,
+.social-media-buttons a:focus {
+  transform: translateY(-2px);
 }
 
 @media (min-width: 768px) {
   .about-grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 991.98px) {
+  body {
+    padding-top: 74px;
+  }
+
+  .landing {
+    padding-top: 120px;
   }
 }
 
 @media (max-width: 767.98px) {
-  .hero-meta li {
-    font-size: 0.9rem;
+  main section {
+    padding: 72px 0;
   }
 
-  .roadmap-item {
-    padding: 18px 20px;
+  .hero-highlights li {
+    font-size: 0.98rem;
+  }
+
+  .hero-meta-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-actions {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .hero-figure {
+    padding: 24px 18px;
+  }
+
+  .profile-image {
+    max-width: 260px;
   }
 }

--- a/index-spa.html
+++ b/index-spa.html
@@ -1,340 +1,469 @@
 <!DOCTYPE html>
 <html lang="es">
-
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Portafolio de Carlos Ortega</title>
+  <title>Carlos Ortega González · Portafolio de Analítica</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
   <link rel="stylesheet" href="./spanish/style.css">
 </head>
-
 <body>
-  <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container">
-      <a class="navbar-brand" href="#" id="pi" onclick="showPiMessage()">π</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <a class="navbar-brand" href="#overview" id="pi" onclick="showPiMessage()" aria-label="Mensaje oculto de PI">π</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Alternar navegación">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ml-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="#about">Sobre mí</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#certifications">Certificaciones</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#portfolio">Portafolio</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#contact">Contacto</a>
-          </li>
+          <li class="nav-item"><a class="nav-link" href="#overview">Resumen</a></li>
+          <li class="nav-item"><a class="nav-link" href="#about">Perfil</a></li>
+          <li class="nav-item"><a class="nav-link" href="#capabilities">Capacidades</a></li>
+          <li class="nav-item"><a class="nav-link" href="#experience">Experiencia</a></li>
+          <li class="nav-item"><a class="nav-link" href="#credentials">Credenciales</a></li>
+          <li class="nav-item"><a class="nav-link" href="#portfolio">Portafolio</a></li>
+          <li class="nav-item"><a class="nav-link" href="#math-lab">Laboratorio</a></li>
+          <li class="nav-item"><a class="nav-link" href="#contact">Contacto</a></li>
         </ul>
       </div>
     </div>
   </nav>
 
-  <!-- Landing Section -->
-  <header class="landing" id="home">
-    <div class="container text-center">
-      <img class="profile-image" src="./english/english/Me&wify.png" alt="Carlos Ortega">
-      <h1 class="display-4">Carlos Ortega González</h1>
-      <ul class="hero-highlights">
-        <li>Socio estratégico de analítica para innovadores en fintech, ciberseguridad y sector público.</li>
-        <li>Generé ahorros de dos dígitos con paneles automatizados y pronósticos impulsados por machine learning.</li>
-        <li>Desarrollador senior de Python que guía equipos multifuncionales desde la idea hasta la puesta en producción.</li>
-      </ul>
-      <div class="hero-cta d-flex flex-column flex-sm-row justify-content-center align-items-center">
-        <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="assets/docs/carlos-ortega-resume.pdf" download>Descargar CV</a>
-        <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar llamada de descubrimiento</a>
-      </div>
-    </div>
-  </header>
-
-  <!-- About Section -->
-  <section class="about" id="about">
-    <div class="container">
-      <h2 class="text-center">Sobre mí</h2><br>
-
-      <p class="about-intro">Ayudo a equipos de fintech y ciberseguridad a traducir datos complejos en productos seguros y escalables que llegan a producción a tiempo.</p>
-
-      <ul class="about-highlights">
-        <li>Automaticé flujos de reportes regulatorios que devuelven 420 horas de analistas por trimestre para enfocarse en la ejecución del roadmap.</li>
-        <li>Diseñé pipelines de analítica que consolidan más de 65 conjuntos de datos dispares para inteligencia de fraude y scoring de riesgo.</li>
-        <li>Lideré escuadras multifuncionales de 8 ingenieros y analistas para entregar insights basados en Python y SQL con 99% de cumplimiento SLA.</li>
-        <li>Contribuyente activo en Python Chile y meetups de seguridad fintech, compartiendo playbooks sobre automatización resiliente.</li>
-        <li>Comprometido con el aprendizaje continuo a través de Coursera, Udacity y experimentación práctica con herramientas emergentes de seguridad.</li>
-      </ul>
-    </div>
-  </section>
-
-
-  <!-- Certifications Section -->
-  <section class="certifications" id="certifications">
-    <div class="container">
-      <h2 class="text-center">Certificaciones</h2><br>
-      <!-- List of Certifications -->
-      <ul>
-        <li>
-          <strong><a href="https://www.udemy.com/certificate/UC-6516cd74-a25b-405d-962d-f3f6296db1c0/">Automate the boring stuff with Python Programming</a></strong>
-          Udemy | Emitido: diciembre 2022
-        </li>
-        <li>
-          <strong><a href="https://www.credly.com/badges/7b6d0fbb-81b4-4b90-a07a-ad49506619cc/linked_in_profile">Data Science Orientation</a></strong>
-          Coursera | Emitido: octubre 2022
-        </li>
-        <li>
-          <strong><a href="https://graduation.udacity.com/confirm/KVWVKZFW">AWS Machine Learning Foundations</a></strong>
-          Udacity | Emitido: septiembre 2022
-        </li>
-        <li>
-          <strong><a href="https://www.efset.org/cert/W91jYa">EF SET English Certificate</a></strong>
-          EF | Emitido: junio 2022
-        </li>
-        <li>
-          <strong><a href="https://www.credly.com/badges/bfe5a0e2-b688-4300-be52-97d4ca8d6f6e/public_url">Google Data Analytics</a></strong>
-          Coursera | Emitido: mayo 2022
-        </li>
-        <li>
-          <strong><a href="https://www.udemy.com/certificate/UC-0d585a57-068e-4d51-9360-48283b103059/?utm_campaign=email&utm_source=sendgrid.com&utm_medium=email">The Self-Taught Programmer</a></strong>
-          Udemy | Emitido: marzo 2022
-        </li>
-        <li>
-          <strong><a href="https://www.udemy.com/certificate/UC-333e6d66-a544-475f-8cf7-747487ad2bc0/">Business Intelligence Analyst</a></strong>
-          Udemy | Emitido: octubre 2021
-        </li>
-        <li>
-          <strong><a href="https://www.credly.com/badges/01c42a0d-8939-41e4-8d26-73a796a95594/public_url">SCRUM Foundation Professional</a></strong>
-          CertiProf | Emitido: noviembre 2020 (actualizado mayo 2023)
-        </li>
-        <li>
-          <strong><a href="https://www.credly.com/badges/6396404d-ef8e-4388-b3d2-4f858afea8f9">Cisco Certified Network Associate Routing and Switching (CCNA R&amp;S)</a></strong>
-          Cisco | Emitido: septiembre 2016
-        </li>
-      </ul>
-    </div>
-  </section>
-
-
-  <!-- Portfolio Section -->
-  <section class="portfolio" id="portfolio">
-    <div class="container">
-      <h2 class="text-center">Portafolio</h2><br>
-
-      <div class="row">
-        <!-- Project 1 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Data Viz: Crecimiento PIB per cápita PPA</h4>
-              <p class="card-text">Bar Chart Race: crecimiento porcentual del PIB per cápita PPA (USD corrientes internacionales) desde 1990 en países de América.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">Flourish</span>
-                <span class="badge badge-tech">ETL</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Aporte:</strong> Seleccioné datos del Banco Mundial, automaticé scripts de limpieza y produje visualizaciones animadas con narrativa.</li>
-                <li><strong>Stack:</strong> Pandas, plantillas de Flourish Studio, GitHub Actions para refresco programado.</li>
-                <li><strong>Volumen:</strong> 31 años × 22 países (~680 registros) actualizados trimestralmente.</li>
-                <li><strong>Impacto:</strong> Entregué insumos listos para sesiones ejecutivas, reduciendo en 3 horas la preparación manual de gráficos por actualización.</li>
-              </ul>
-              <a href="https://public.flourish.studio/visualisation/9177797/" class="btn btn-primary">Ver visualización</a>
+  <main>
+    <header class="landing" id="overview">
+      <div class="container">
+        <div class="row align-items-center hero-layout">
+          <div class="col-lg-6">
+            <span class="hero-eyebrow">Líder en analítica e ingeniería de riesgo</span>
+            <h1 class="display-4">Carlos Ortega González</h1>
+            <p class="hero-lede">Orquesto equipos de datos bilingües que convierten desafíos ambiguos de riesgo, cumplimiento y producto en soluciones auditables con Python, SQL y APIs.</p>
+            <ul class="hero-highlights">
+              <li>Devolví <strong>420 horas trimestrales de analistas</strong> a la ejecución del roadmap mediante automatización de reportes regulatorios.</li>
+              <li>Entregué una experiencia de consulta antifraude <strong>6× más rápida</strong> al diseñar servicios FastAPI y pipelines de datos asíncronos.</li>
+              <li>Socio de confianza para fintech, ciberseguridad y sector público en Chile, Latinoamérica y equipos remotos en EE. UU.</li>
+            </ul>
+            <div class="hero-cta d-flex flex-column flex-sm-row align-items-sm-center">
+              <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="assets/docs/carlos-ortega-resume.pdf" download>Descargar CV</a>
+              <a class="btn btn-outline-light btn-lg" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar llamada</a>
             </div>
           </div>
-        </div>
-
-        <!-- Project 2 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Data Viz: Inflación acumulada en países de la OCDE</h4>
-              <p class="card-text">Bar Chart Race: inflación acumulada en los países de la OCDE entre 1990 y 2020.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">Flourish</span>
-                <span class="badge badge-tech">OECD API</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Aporte:</strong> Construí scripts de extracción con la API de la OCDE y unifiqué índices IPC para comparar países.</li>
-                <li><strong>Stack:</strong> Requests, Pandas, Flourish Studio, Airtable para flujo de anotaciones.</li>
-                <li><strong>Volumen:</strong> 30 años × 38 miembros de la OCDE (~1.1K registros).</li>
-                <li><strong>Impacto:</strong> Permití que analistas detectaran outliers de inflación en menos de 5 minutos, acelerando la producción del boletín.</li>
-              </ul>
-              <a href="https://public.flourish.studio/visualisation/9291169/" class="btn btn-primary">Ver visualización</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 3 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Prize Scrapper para polla.cl</h4>
-              <p class="card-text">Script en Python que extrae información de premios del sitio de apuestas chileno polla.cl y actualiza una Google Sheet.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">BeautifulSoup</span>
-                <span class="badge badge-tech">Google Sheets API</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Aporte:</strong> Investigué las tablas de premios, implementé scraping resiliente y orquesté actualizaciones diarias para los interesados.</li>
-                <li><strong>Stack:</strong> Requests, BeautifulSoup, gspread, contenedor Docker con cron.</li>
-                <li><strong>Volumen:</strong> Más de 80 sorteos capturados semanalmente con historial.</li>
-                <li><strong>Impacto:</strong> Automaticé la actualización semanal, reduciendo 4 horas de trabajo manual y eliminando errores de reporte.</li>
-              </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/polla#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">README del proyecto</a>
-              </div>
-              <a href="https://github.com/cortega26/polla" class="btn btn-primary">Ver proyecto en GitHub</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 4 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">PDF to Text Analyzer</h4>
-              <p class="card-text">Script en Python para descargar PDFs, convertirlos a texto y realizar análisis, incluyendo identificación de idioma y conteo de frecuencia.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">NLTK</span>
-                <span class="badge badge-tech">AWS S3</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Aporte:</strong> Diseñé la canalización de ingesta, normalicé corpus multilingües y empaqueté utilidades reutilizables de línea de comandos.</li>
-                <li><strong>Stack:</strong> PyPDF2, langdetect, NLTK, AWS S3 para archivado, pruebas con GitHub Actions.</li>
-                <li><strong>Volumen:</strong> Procesa lotes de más de 500 PDFs (aprox. 1.2 GB) por ejecución.</li>
-                <li><strong>Impacto:</strong> Aceleré las revisiones de cumplimiento al resaltar frases clave 60% más rápido para el equipo de auditoría.</li>
-              </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/PDF-Text-Analyzer#usage" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Documentación de uso</a>
-              </div>
-              <a href="https://github.com/cortega26/PDF-Text-Analyzer" class="btn btn-primary">Ver proyecto en GitHub</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 5 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">Fast Search API</h4>
-              <p class="card-text">Implementación eficiente en FastAPI para buscar datos JSON usando filtros por nombre, apellido, RUT y edad.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">FastAPI</span>
-                <span class="badge badge-tech">Docker</span>
-                <span class="badge badge-tech">PostgreSQL</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Aporte:</strong> Arquitecté endpoints asíncronos, indexé campos de búsqueda y añadí tableros de observabilidad.</li>
-                <li><strong>Stack:</strong> FastAPI, SQLAlchemy, PostgreSQL, Docker Compose, pytest.</li>
-                <li><strong>Volumen:</strong> Probado con 2,5 millones de registros con latencia &lt; 150 ms.</li>
-                <li><strong>Impacto:</strong> Entregué una experiencia de consulta 6× más rápida para equipos de soporte que validan fraudes.</li>
-              </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/FastSearchAPI#api-reference" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Referencia de la API</a>
-              </div>
-              <a href="https://github.com/cortega26/FastSearchAPI" class="btn btn-primary">Ver proyecto en GitHub</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project 6 Card -->
-        <div class="col-md-6">
-          <div class="card mb-4 custom-card">
-            <div class="card-body text-center">
-              <h4 class="card-title">File Extractor Pro</h4>
-              <p class="card-text">Suite de automatización de escritorio que inventaría carpetas, aplica filtros de cumplimiento y genera reportes de extracción con evidencia anti-manipulación.</p>
-              <div class="project-badges">
-                <span class="badge badge-tech">Python</span>
-                <span class="badge badge-tech">Tkinter</span>
-                <span class="badge badge-tech">AsyncIO</span>
-              </div>
-              <ul class="project-details text-left">
-                <li><strong>Aporte:</strong> Diseñé el motor asíncrono de extracción, reforcé el logging estructurado y entregué un centro de mando en Tkinter para revisores no técnicos.</li>
-                <li><strong>Stack:</strong> Python 3.9+, Tkinter, asyncio, registros auditables con RotatingFileHandler.</li>
-                <li><strong>Volumen:</strong> Procesa árboles de directorios grandes sin congelar la interfaz gracias a workers en segundo plano.</li>
-                <li><strong>Impacto:</strong> Permite a equipos de cumplimiento exportar evidencias bajo demanda sin triage manual de archivos.</li>
-              </ul>
-              <div class="project-links">
-                <a href="https://github.com/cortega26/File-Extractor-Pro#features" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Resumen de funcionalidades</a>
-              </div>
-              <a href="https://github.com/cortega26/File-Extractor-Pro" class="btn btn-primary">Ver proyecto en GitHub</a>
+          <div class="col-lg-5 offset-lg-1">
+            <figure class="hero-figure">
+              <img class="profile-image" src="./english/Me&wify.png" alt="Retrato de Carlos Ortega">
+              <figcaption>Basado en Santiago, Chile · Disponible para roles remotos o híbridos en LATAM y husos compatibles con EE. UU.</figcaption>
+            </figure>
+            <div class="hero-meta-grid" role="list">
+              <article class="hero-meta-card" role="listitem">
+                <h3>Roles objetivo</h3>
+                <p>Senior Data Analyst · Analytics Engineer · Technical Product Manager</p>
+              </article>
+              <article class="hero-meta-card" role="listitem">
+                <h3>Modalidades</h3>
+                <p>Contrato o tiempo completo · Aviso de 30 días · Facturación internacional disponible</p>
+              </article>
+              <article class="hero-meta-card" role="listitem">
+                <h3>Estilo de colaboración</h3>
+                <p>Workshops de discovery, ritmos ágiles y relatos ejecutivos respaldados por activos reproducibles.</p>
+              </article>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </header>
 
-
-  <!-- Contact Section -->
-  <section class="contact" id="contact">
-    <div class="container">
-      <h2 class="text-center">Contacto</h2><br>
-      <div class="row">
-        <div class="col-lg-5 mb-4">
-          <div class="contact-summary h-100">
-            <p>Construyamos productos de datos resilientes. Comparte un brief o invítame a una llamada de descubrimiento; responderé con próximos pasos y recursos alineados a tu hoja de ruta.</p>
-            <div class="contact-actions">
-              <a class="btn btn-cta contact-btn" href="mailto:carlosortega77@gmail.com?subject=Solicitud%20de%20CV" rel="noopener">Solicitar CV</a>
-              <a class="btn btn-outline-light contact-btn" href="https://www.linkedin.com/in/cortega26" target="_blank" rel="noopener">Conectar en LinkedIn</a>
-              <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar vía Calendly</a>
-            </div>
-            <p class="contact-response">Tiempo estimado de respuesta: dentro de 48 horas hábiles, con disponibilidad para llamadas martes a jueves, 9:00–15:00 CLT.</p>
-            <p class="contact-response">¿Necesitas respuesta urgente? Escríbeme directo y priorizaré incidentes en producción.</p>
-          </div>
-        </div>
-        <div class="col-lg-7 mb-4">
-          <form class="contact-form" id="contact-form">
-            <div class="form-group">
-              <label class="sr-only" for="name">Tu nombre</label>
-              <input type="text" class="form-control" id="name" name="name" placeholder="Tu nombre" required>
-            </div>
-            <div class="form-group">
-              <label class="sr-only" for="email">Tu correo</label>
-              <input type="email" class="form-control" id="email" name="email" placeholder="Tu correo" required>
-            </div>
-            <div class="form-group">
-              <label class="sr-only" for="subject">Asunto</label>
-              <input type="text" class="form-control" id="subject" name="subject" placeholder="Proyecto o rol" required>
-            </div>
-            <div class="form-group">
-              <label class="sr-only" for="message">Mensaje</label>
-              <textarea class="form-control" id="message" name="message" rows="5" placeholder="Comparte contexto, plazos y objetivos" required></textarea>
-            </div>
-            <button type="submit" class="btn btn-primary contact-submit">Abrir borrador de correo</button>
-          </form>
+    <section class="about" id="about">
+      <div class="container">
+        <h2 class="section-title text-center">Perfil en síntesis</h2>
+        <p class="section-intro text-center">Combino más de 15 años de liderazgo operativo con ingeniería de analítica moderna para entregar productos de datos resilientes. Mi enfoque mezcla facilitación de discovery, experimentación matemática y automatización productiva para que los equipos decidan con menos riesgo y mayor velocidad.</p>
+        <div class="about-grid">
+          <article class="about-card">
+            <h3>A quién acompaño</h3>
+            <ul class="about-list">
+              <li>Fintech, ciberseguridad y agencias públicas con cargas críticas de regulación y fraude.</li>
+              <li>Scale-ups que necesitan relatos de datos bilingües para alinear ingeniería, finanzas y sponsors ejecutivos.</li>
+              <li>Equipos operativos que evolucionan planillas hacia plataformas observables impulsadas por APIs.</li>
+            </ul>
+          </article>
+          <article class="about-card">
+            <h3>Cómo trabajo</h3>
+            <ul class="about-list">
+              <li>Diseño discovery transversal para clarificar requerimientos, métricas de éxito y tolerancia al riesgo.</li>
+              <li>Lanzo servicios modulares en Python, SQL y FastAPI con CI, documentación y traspaso de conocimiento.</li>
+              <li>Mantengo roadmaps en GitHub, walkthroughs en Loom y reportes de avance que sostienen la confianza.</li>
+            </ul>
+          </article>
+          <article class="about-card">
+            <h3>En qué me enfoco hoy</h3>
+            <ul class="about-list">
+              <li>Estadística avanzada, optimización y preparación para AWS Data Analytics Specialty.</li>
+              <li>Arquitecturas de streaming que detectan anomalías en tiempo real para seguridad y trading.</li>
+              <li>Mentoría a comunidades en Python Chile y grupos de analítica.</li>
+            </ul>
+          </article>
         </div>
       </div>
+    </section>
 
-      <!-- Social Networks -->
-      <div class="container text-center">
-        <div class="social-media-container">
-          <div class="social-media-buttons btn-group">
-            <a href="https://github.com/cortega26" class="btn btn-dark"><i class="fab fa-github"></i></a>
-            <a href="https://www.linkedin.com/in/cortega26" class="btn btn-primary"><i class="fab fa-linkedin"></i></a>
-            <a href="https://twitter.com/cortega26" class="btn btn-dark"><i class="fab fa-twitter"></i></a>
-            <a href="https://wa.me/56951118901" class="btn btn-success"><i class="fab fa-whatsapp"></i></a>
-            <a href="mailto:carlosortega77@gmail.com" class="btn btn-dark"><i class="far fa-envelope"></i></a>
+    <section class="capabilities" id="capabilities">
+      <div class="container">
+        <h2 class="section-title text-center">Capacidades clave</h2>
+        <p class="section-subtitle text-center">Cada proyecto se apoya en resultados medibles, rituales colaborativos y activos reutilizables.</p>
+        <div class="row">
+          <div class="col-md-4 mb-4">
+            <article class="capability-card h-100">
+              <h3>Comandante de automatización</h3>
+              <p>Transformo procesos manuales fragmentados en flujos asíncronos auditables que liberan tiempo analítico.</p>
+              <ul>
+                <li>File Extractor Pro estandariza paquetes de evidencia y controles de resiliencia.</li>
+                <li>PDF Text Analyzer acelera revisiones multilingües con detección de anomalías un 60% más rápida.</li>
+              </ul>
+            </article>
+          </div>
+          <div class="col-md-4 mb-4">
+            <article class="capability-card h-100">
+              <h3>Traductor de matemática y modelos</h3>
+              <p>Destilo estadística y forecast en relatos claros con notebooks, pruebas y pipelines reproducibles.</p>
+              <ul>
+                <li>Repos de Foobar y Google Challenges documentan rigurosidad algorítmica con análisis Big-O.</li>
+                <li>Backtest Trading cuantifica escenarios de riesgo antes de automatizar en producción.</li>
+              </ul>
+            </article>
+          </div>
+          <div class="col-md-4 mb-4">
+            <article class="capability-card h-100">
+              <h3>Aliado de stakeholders</h3>
+              <p>Facilito la alineación entre producto, seguridad y finanzas alrededor de ROI claro y cadencias de entrega.</p>
+              <ul>
+                <li>Backlogs de FastSearchAPI co-creados con soporte para asegurar latencias &lt;150&nbsp;ms.</li>
+                <li>Notas de release y tableros ejecutivos que informan sin interrumpir el tiempo maker.</li>
+              </ul>
+            </article>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
+    <section class="experience" id="experience">
+      <div class="container">
+        <h2 class="section-title text-center">Hitos profesionales</h2>
+        <p class="section-subtitle text-center">Una evolución transparente desde logística de seguridad nacional hacia liderazgo en automatización de datos.</p>
+        <div class="roadmap-timeline">
+          <article class="roadmap-item">
+            <span class="roadmap-date">2021</span>
+            <h3>Automatización de narrativa macroeconómica</h3>
+            <p>Lancé automatizaciones del PIB per cápita del Banco Mundial y dashboards Flourish reutilizados trimestralmente por ejecutivos.</p>
+          </article>
+          <article class="roadmap-item">
+            <span class="roadmap-date">2022</span>
+            <h3>Fundamentos de datos formalizados</h3>
+            <p>Completé certificaciones de Google Data Analytics, AWS ML Foundations y Udacity mientras reconstruía CV y GitHub con resultados cuantificados.</p>
+          </article>
+          <article class="roadmap-item">
+            <span class="roadmap-date">2023</span>
+            <h3>APIs listas para producción &amp; herramientas de cumplimiento</h3>
+            <p>Publiqué FastSearchAPI, File Extractor Pro y PDF Text Analyzer con Docker, CI y documentación al estándar enterprise.</p>
+          </article>
+          <article class="roadmap-item">
+            <span class="roadmap-date">2024</span>
+            <h3>Inteligencia de decisiones y analítica en streaming</h3>
+            <p>Implementé alertas de Crypto Price Tracker, inteligencia de rareza PoGo y comencé preparación pública para AWS Data Analytics Specialty.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="certifications" id="credentials">
+      <div class="container">
+        <h2 class="section-title text-center">Credenciales y aprendizaje continuo</h2>
+        <div class="row">
+          <div class="col-lg-5 mb-4">
+            <div class="credential-card h-100">
+              <h3>En curso</h3>
+              <ul>
+                <li><strong>AWS Data Analytics Specialty</strong> · Autoestudio y laboratorios comunitarios · Meta: Q4 2024</li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-lg-7 mb-4">
+            <div class="credential-card h-100">
+              <h3>Certificaciones destacadas</h3>
+              <ul>
+                <li><strong><a href="https://www.udemy.com/certificate/UC-6516cd74-a25b-405d-962d-f3f6296db1c0/" target="_blank" rel="noopener">Automate the Boring Stuff with Python Programming</a></strong> · Udemy · Emitido dic 2022</li>
+                <li><strong><a href="https://www.credly.com/badges/7b6d0fbb-81b4-4b90-a07a-ad49506619cc/linked_in_profile" target="_blank" rel="noopener">Data Science Orientation</a></strong> · Coursera · Emitido oct 2022</li>
+                <li><strong><a href="https://graduation.udacity.com/confirm/KVWVKZFW" target="_blank" rel="noopener">AWS Machine Learning Foundations</a></strong> · Udacity · Emitido sep 2022</li>
+                <li><strong><a href="https://www.efset.org/cert/W91jYa" target="_blank" rel="noopener">EF SET English Certificate (C2)</a></strong> · EF · Emitido jun 2022</li>
+                <li><strong><a href="https://www.credly.com/badges/bfe5a0e2-b688-4300-be52-97d4ca8d6f6e/public_url" target="_blank" rel="noopener">Google Data Analytics</a></strong> · Coursera · Emitido may 2022</li>
+                <li><strong><a href="https://www.udemy.com/certificate/UC-0d585a57-068e-4d51-9360-48283b103059/" target="_blank" rel="noopener">The Self-Taught Programmer</a></strong> · Udemy · Emitido mar 2022</li>
+                <li><strong><a href="https://www.udemy.com/certificate/UC-333e6d66-a544-475f-8cf7-747487ad2bc0/" target="_blank" rel="noopener">Business Intelligence Analyst</a></strong> · Udemy · Emitido oct 2021</li>
+                <li><strong><a href="https://www.credly.com/badges/01c42a0d-8939-41e4-8d26-73a796a95594/public_url" target="_blank" rel="noopener">SCRUM Foundation Professional</a></strong> · CertiProf · Emitido nov 2020 (actualizado may 2023)</li>
+                <li><strong><a href="https://www.credly.com/badges/6396404d-ef8e-4388-b3d2-4f858afea8f9" target="_blank" rel="noopener">Cisco Certified Network Associate R&amp;S</a></strong> · Cisco · Emitido sep 2016</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="portfolio" id="portfolio">
+      <div class="container">
+        <h2 class="section-title text-center">Portafolio destacado</h2>
+        <p class="section-subtitle text-center">Casos que abarcan automatización, APIs y analítica interactiva. Cada repositorio incluye guías de despliegue, roadmaps y métricas para replicar resultados.</p>
+        <div class="row">
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Data Viz: Crecimiento PIB per cápita (Américas)</h3>
+                <p class="card-text">Historias animadas en Flourish que siguen el crecimiento del PIB per cápita PPA de 22 países desde 1990.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">Flourish</span>
+                  <span class="badge badge-tech">ETL</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Aporte:</strong> Curación de datos del Banco Mundial, scripts de limpieza y visuales listos para directorio.</li>
+                  <li><strong>Impacto:</strong> Reducción de tres horas por actualización en la preparación manual de gráficos.</li>
+                </ul>
+                <a href="https://public.flourish.studio/visualisation/9177797/" class="btn btn-primary" target="_blank" rel="noopener">Ver visualización</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Data Viz: Inflación acumulada OCDE</h3>
+                <p class="card-text">Bar chart race con inflación acumulada para los 38 miembros de la OCDE durante tres décadas.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">Flourish</span>
+                  <span class="badge badge-tech">OECD API</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Aporte:</strong> Extracción vía API de la OCDE y armonización de índices IPC comparables.</li>
+                  <li><strong>Impacto:</strong> Analistas detectan outliers en cinco minutos, acelerando boletines.</li>
+                </ul>
+                <a href="https://public.flourish.studio/visualisation/9291169/" class="btn btn-primary" target="_blank" rel="noopener">Ver visualización</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Prize Scraper para polla.cl</h3>
+                <p class="card-text">Ingesta automatizada del sitio de apuestas chileno con actualizaciones diarias hacia Google Sheets.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">BeautifulSoup</span>
+                  <span class="badge badge-tech">Google Sheets API</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Aporte:</strong> Ingeniería inversa de tablas, scraping resiliente y notificaciones a stakeholders.</li>
+                  <li><strong>Impacto:</strong> Eliminación de cuatro horas semanales de trabajo manual manteniendo histórico.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/polla#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">README del proyecto</a>
+                </div>
+                <a href="https://github.com/cortega26/polla" class="btn btn-primary" target="_blank" rel="noopener">Ver en GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">PDF to Text Analyzer</h3>
+                <p class="card-text">Toolkit CLI para descargar PDFs, extraer texto y detectar anomalías en corpus multilingües.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">NLTK</span>
+                  <span class="badge badge-tech">AWS S3</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Aporte:</strong> Diseño de ingesta, normalización de corpus y empaquetado de utilidades reutilizables.</li>
+                  <li><strong>Impacto:</strong> Destaca frases clave un 60% más rápido para equipos de cumplimiento.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/PDF-Text-Analyzer#usage" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Documentación de uso</a>
+                </div>
+                <a href="https://github.com/cortega26/PDF-Text-Analyzer" class="btn btn-primary" target="_blank" rel="noopener">Ver en GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">FastSearchAPI</h3>
+                <p class="card-text">Servicio FastAPI de alto desempeño con búsquedas milimétricas sobre registros ciudadanos y listas de fraude.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">FastAPI</span>
+                  <span class="badge badge-tech">Docker</span>
+                  <span class="badge badge-tech">PostgreSQL</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Aporte:</strong> Endpoints asíncronos, campos indexados y tableros de observabilidad.</li>
+                  <li><strong>Impacto:</strong> Consultas &lt;150&nbsp;ms para equipos de soporte antifraude.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/FastSearchAPI#api-reference" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Referencia API</a>
+                </div>
+                <a href="https://github.com/cortega26/FastSearchAPI" class="btn btn-primary" target="_blank" rel="noopener">Ver en GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">File Extractor Pro</h3>
+                <p class="card-text">Suite de escritorio que inventaría carpetas, aplica filtros de cumplimiento y genera reportes con evidencia anti-manipulación.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">Tkinter</span>
+                  <span class="badge badge-tech">AsyncIO</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Aporte:</strong> Motor asíncrono de extracción y logging estructurado para usuarios no técnicos.</li>
+                  <li><strong>Impacto:</strong> Exportación de evidencia on-demand sin triage manual.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/File-Extractor-Pro#features" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Resumen de features</a>
+                </div>
+                <a href="https://github.com/cortega26/File-Extractor-Pro" class="btn btn-primary" target="_blank" rel="noopener">Ver en GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Crypto Price Tracker</h3>
+                <p class="card-text">Monitor en tiempo real de Binance con alertas configurables vía email y umbrales dinámicos.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">AsyncIO</span>
+                  <span class="badge badge-tech">SMTP</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Aporte:</strong> Orquestación de polling, rate limiting y notificaciones de alto valor.</li>
+                  <li><strong>Impacto:</strong> Mantiene a traders informados de variaciones ±5% sin vigilar dashboards.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/crypto-price-tracker#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">README del proyecto</a>
+                </div>
+                <a href="https://github.com/cortega26/crypto-price-tracker" class="btn btn-primary" target="_blank" rel="noopener">Ver en GitHub</a>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-6">
+            <article class="card custom-card h-100">
+              <div class="card-body">
+                <h3 class="card-title">PoGo Rarity Intelligence</h3>
+                <p class="card-text">Experiencia CLI y Streamlit que jerarquiza spawns de Pokémon GO para optimizar trades y eventos.</p>
+                <div class="project-badges">
+                  <span class="badge badge-tech">Python</span>
+                  <span class="badge badge-tech">Streamlit</span>
+                  <span class="badge badge-tech">Data Pipelines</span>
+                </div>
+                <ul class="project-details">
+                  <li><strong>Aporte:</strong> Integración de datos públicos, heurísticas de rareza y caching para consultas instantáneas.</li>
+                  <li><strong>Impacto:</strong> Guía a más de 2K visitantes mensuales en cómo invertir recursos del juego.</li>
+                </ul>
+                <div class="project-links">
+                  <a href="https://github.com/cortega26/PoGo#readme" class="btn btn-outline-light btn-sm" target="_blank" rel="noopener">Demo en Streamlit</a>
+                </div>
+                <a href="https://github.com/cortega26/PoGo" class="btn btn-primary" target="_blank" rel="noopener">Ver en GitHub</a>
+              </div>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="math-lab" id="math-lab">
+      <div class="container">
+        <h2 class="section-title text-center">Laboratorio de matemática &amp; repos técnicos</h2>
+        <p class="section-subtitle text-center">Evidencia de práctica continua en matemática, algoritmos y tooling: cada repo incluye README, pruebas e issues con próximos experimentos.</p>
+        <div class="row">
+          <div class="col-md-6 mb-4">
+            <article class="math-card h-100">
+              <h3>Desafíos algorítmicos</h3>
+              <p>Problemas de Google Foobar y entrevistas curadas con análisis de trade-offs, pseudocódigo y pruebas unitarias.</p>
+              <ul>
+                <li><a href="https://github.com/cortega26/Foobar" target="_blank" rel="noopener">Foobar</a>: Puzzles de greedy, BFS y teoría de números con análisis de complejidad.</li>
+                <li><a href="https://github.com/cortega26/Challenges" target="_blank" rel="noopener">Challenges</a>: Evaluaciones laborales con supuestos y datasets de validación.</li>
+              </ul>
+            </article>
+          </div>
+          <div class="col-md-6 mb-4">
+            <article class="math-card h-100">
+              <h3>Experimentos cuantitativos</h3>
+              <p>Backtests, validadores de RUT y cuadernos de forecasting que demuestran rigurosidad estadística.</p>
+              <ul>
+                <li><a href="https://github.com/cortega26/Backtest-trading" target="_blank" rel="noopener">Backtest Trading</a>: Escenarios, ratios de Sharpe y plantillas de position sizing.</li>
+                <li><a href="https://github.com/cortega26/rutificador" target="_blank" rel="noopener">Rutificador</a>: Validación del RUT chileno con doctests e integración continua.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+        <p class="math-lab-footer text-center">Revisa el <a href="https://github.com/cortega26?tab=repositories" target="_blank" rel="noopener">perfil completo en GitHub</a> para notebooks, bots de trading y experimentos civic-tech.</p>
+      </div>
+    </section>
+
+    <section class="contact" id="contact">
+      <div class="container">
+        <h2 class="section-title text-center">Colaboremos</h2>
+        <p class="section-subtitle text-center">Comparte contexto, plazos y resultados deseados; responderé con próximos pasos y recursos a medida dentro de dos días hábiles.</p>
+        <div class="row">
+          <div class="col-lg-5 mb-4">
+            <div class="contact-summary h-100">
+              <p>Construyamos productos de datos resilientes. Ya sea liderazgo interino o automatización puntual, aporto discovery estructurado, entrega transparente y relatos ejecutivos.</p>
+              <div class="contact-actions">
+                <a class="btn btn-cta contact-btn" href="mailto:carlosortega77@gmail.com?subject=Solicitud%20de%20CV" rel="noopener">Solicitar CV</a>
+                <a class="btn btn-outline-light contact-btn" href="https://www.linkedin.com/in/cortega26" target="_blank" rel="noopener">Conectar en LinkedIn</a>
+                <a class="btn btn-success contact-btn" href="https://calendly.com/cortega26" target="_blank" rel="noopener">Agendar por Calendly</a>
+              </div>
+              <p class="contact-response">Tiempo de respuesta: dentro de 48 horas hábiles · Llamadas martes a jueves, 09:00–15:00 CLT.</p>
+              <p class="contact-response">¿Caso urgente? Escríbeme directo y priorizaré incidentes productivos.</p>
+            </div>
+          </div>
+          <div class="col-lg-7 mb-4">
+            <form class="contact-form" id="contact-form">
+              <div class="form-group">
+                <label class="sr-only" for="name">Tu nombre</label>
+                <input type="text" class="form-control" id="name" name="name" placeholder="Tu nombre" required>
+              </div>
+              <div class="form-group">
+                <label class="sr-only" for="email">Tu correo</label>
+                <input type="email" class="form-control" id="email" name="email" placeholder="Tu correo" required>
+              </div>
+              <div class="form-group">
+                <label class="sr-only" for="subject">Proyecto o rol</label>
+                <input type="text" class="form-control" id="subject" name="subject" placeholder="Proyecto o rol" required>
+              </div>
+              <div class="form-group">
+                <label class="sr-only" for="message">Mensaje</label>
+                <textarea class="form-control" id="message" name="message" rows="5" placeholder="Comparte contexto, plazos y objetivos" required></textarea>
+              </div>
+              <button type="submit" class="btn btn-primary contact-submit">Abrir borrador de correo</button>
+            </form>
+          </div>
+        </div>
+        <div class="social-media-container text-center">
+          <div class="social-media-buttons btn-group" role="group" aria-label="Redes sociales">
+            <a href="https://github.com/cortega26" class="btn btn-dark" target="_blank" rel="noopener" aria-label="GitHub"><i class="fab fa-github"></i></a>
+            <a href="https://www.linkedin.com/in/cortega26" class="btn btn-primary" target="_blank" rel="noopener" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+            <a href="https://twitter.com/cortega26" class="btn btn-dark" target="_blank" rel="noopener" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+            <a href="https://wa.me/56951118901" class="btn btn-success" target="_blank" rel="noopener" aria-label="WhatsApp"><i class="fab fa-whatsapp"></i></a>
+            <a href="mailto:carlosortega77@gmail.com" class="btn btn-dark" aria-label="Correo"><i class="far fa-envelope"></i></a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
 
   <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
   <script src="./spanish/script.js"></script>
-
 </body>
-
 </html>

--- a/spanish/script.js
+++ b/spanish/script.js
@@ -1,120 +1,53 @@
-
-// For example, smooth scrolling to sections on clicking nav links
-
 $(document).ready(function() {
-  $(".nav-link").on("click", function(event) {
-    event.preventDefault();
-    const target = $(this).attr("href");
-    $("html, body").animate({
-      scrollTop: $(target).offset().top
-    }, 800);
+  $('a[href^="#"]').on('click', function(event) {
+    const target = $(this.getAttribute('href'));
+    if (target.length) {
+      event.preventDefault();
+      $('html, body').animate({
+        scrollTop: target.offset().top
+      }, 800);
+    }
   });
 });
 
-
-/* // Define an array of engaging messages
-const messages = [
-    "It's about 3.1416 \nThis is not a Sandra Bullock movie",
-    "Congratulations! You've unlocked the power of π. But beware, secrets come with a price...",
-    "Spiders crawl, secrets beckon. How deep will you venture into the digital abyss?",
-    "The cosmos whisper, the code calls. A universe of mysteries awaits...",
-    "A portal to the unknown has been opened. The ancient symbol of π reveals hidden truths...",
-    "Illuminating the shadows of the digital realm, you've embarked on a thrilling quest...",
-    "Binary whispers echo through the cyberspace. The enigma of π holds untold wonders...",
-    "Decoding the language of numbers, you've awakened a dormant power within...",
-    "The world of possibilities unfolds before you. The journey has just begun...",
-  ];
-  
-  // Initialize click count
-  let clickCount = 0;
-  
-  function showPiMessage() {
-    // Check if all messages have been displayed
-    if (clickCount === messages.length) {
-      // Last message with the call to action
-      const finalMessage = "I hope you had enough fun, now it's time to hire me. Let's create something extraordinary together!";
-      alert(finalMessage);
-    } else {
-      // Get the current message based on the click count
-      const message = messages[clickCount % messages.length];
-  
-      // Increment click count for the next click
-      clickCount++;
-  
-      alert(message);
-    }
-  } */
-
-
-// Define messages for English
 const messagesEn = [
-  "It's about 3.1416 \nThis is not a Sandra Bullock movie",
-    "Congratulations! You've unlocked the power of π. But beware, secrets come with a price...",
-    "Spiders crawl, secrets beckon. How deep will you venture into the digital abyss?",
-    "The cosmos whisper, the code calls. A universe of mysteries awaits...",
-    "A portal to the unknown has been opened. The ancient symbol of π reveals hidden truths...",
-    "Illuminating the shadows of the digital realm, you've embarked on a thrilling quest...",
-    "Binary whispers echo through the cyberspace. The enigma of π holds untold wonders...",
-    "Decoding the language of numbers, you've awakened a dormant power within...",
-    "The world of possibilities unfolds before you. The journey has just begun...",
+  "Analytics should feel calm and reliable—curious how I returned 420 hours to analysts?",
+  "Bilingual partner here. Need a guide through compliance, fraud, or growth dashboards?",
+  "FastAPI, SQL, and storytelling—pick two and I'll add the third.",
+  "Serious about automation readiness? Let's co-design your next delivery playbook.",
+  "Looking for algorithmic proof? My math lab is just a few scrolls away."
 ];
 
-// Define messages for Spanish
 const messagesEs = [
-  "¡Es sobre 3.1416! \nEsto no es una película de Sandra Bullock",
-  "¡Felicidades! Has desbloqueado el poder de π. Pero cuidado, los secretos tienen un precio...",
-  "Las arañas se deslizan, los secretos llaman. ¿Qué tan profundo te atreves a ir en el abismo digital?",
-  "El cosmos susurra y el código llama. Un universo de misterios te espera...",
-  "Se ha abierto un portal a lo desconocido. El símbolo ancestral de π revela verdades ocultas...",
-  "Iluminaste las sombras del reino digital; te embarcaste en una aventura emocionante...",
-  "Susurros binarios recorren el ciberespacio. El enigma de π guarda maravillas indescriptibles...",
-  "Al descifrar el lenguaje de los números despertaste un poder latente...",
-  "El mundo de posibilidades se despliega ante ti. El viaje apenas comienza...",
+  "La analítica debe sentirse segura y predecible—¿quieres saber cómo devolví 420 horas a los analistas?",
+  "Compañero bilingüe disponible. ¿Necesitas guía en cumplimiento, fraude o dashboards de crecimiento?",
+  "FastAPI, SQL y storytelling: elige dos y yo sumo el tercero.",
+  "¿Listo para automatizar con solidez? Diseñemos juntos tu próximo playbook de entrega.",
+  "¿Buscas evidencia algorítmica? Mi laboratorio matemático está unas secciones más abajo."
 ];
 
-// Initialize click count
 let clickCount = 0;
 
 function showPiMessage() {
-  // Check the value of the lang attribute
-  const langAttribute = document.documentElement.getAttribute("lang");
-  
-  // Determine the messages based on the language
-  const isSpanish = langAttribute && langAttribute.startsWith("es");
+  const langAttribute = document.documentElement.getAttribute('lang');
+  const isSpanish = langAttribute && langAttribute.startsWith('es');
+  const messages = isSpanish ? messagesEs : messagesEn;
 
-  let messages;
-  if (isSpanish) {
-      messages = messagesEs;
-  } else {
-      messages = messagesEn;
+  if (clickCount >= messages.length) {
+    const finalMessage = isSpanish
+      ? '¿Listo para conversar? Agenda una llamada de descubrimiento y avancemos.'
+      : 'Ready to talk? Book a discovery call and let’s move forward.';
+    alert(finalMessage);
+    clickCount = 0;
+    return;
   }
 
-  // Check if all messages have been displayed
-  if (clickCount === messages.length) {
-      // Last message with the call to action
-      const finalMessage = isSpanish
-        ? "Espero que te hayas divertido, ahora es momento de contratarme. ¡Creemos algo extraordinario juntos!"
-        : "I hope you had enough fun, now it's time to hire me. Let's create something extraordinary together!";
-      alert(finalMessage);
-  } else {
-      // Get the current message based on the click count
-      const message = messages[clickCount % messages.length];
-
-      // Increment click count for the next click
-      clickCount++;
-
-      alert(message);
-  }
+  alert(messages[clickCount]);
+  clickCount += 1;
 }
 
-
-
-
-
-
-
 function sendEmailFallback(event) {
-  const contactForm = document.getElementById("contact-form");
+  const contactForm = document.getElementById('contact-form');
 
   if (!contactForm) {
     return;
@@ -122,26 +55,27 @@ function sendEmailFallback(event) {
 
   event.preventDefault();
 
-  const langAttribute = document.documentElement.getAttribute("lang");
-  const isSpanish = langAttribute && langAttribute.startsWith("es");
+  const langAttribute = document.documentElement.getAttribute('lang');
+  const isSpanish = langAttribute && langAttribute.startsWith('es');
 
-  const name = contactForm.elements["name"].value.trim();
-  const email = contactForm.elements["email"].value.trim();
-  const subject = contactForm.elements["subject"].value.trim();
-  const message = contactForm.elements["message"].value.trim();
+  const name = contactForm.elements['name'].value.trim();
+  const email = contactForm.elements['email'].value.trim();
+  const subject = contactForm.elements['subject'].value.trim();
+  const message = contactForm.elements['message'].value.trim();
 
-  const fallbackSubject = isSpanish ? "Consulta de portafolio" : "Portfolio Inquiry";
+  const fallbackSubject = isSpanish ? 'Consulta de portafolio' : 'Portfolio Inquiry';
   const composedSubject = subject
     ? `${subject} — ${name || fallbackSubject}`
-    : `${fallbackSubject} ${isSpanish ? "de" : "from"} ${name || (isSpanish ? "Visita al sitio web" : "Website Visitor")}`;
+    : `${fallbackSubject} ${isSpanish ? 'de' : 'from'} ${name || (isSpanish ? 'Visita al sitio web' : 'Website Visitor')}`;
+
   const bodyLines = [
-    `${isSpanish ? "Nombre" : "Name"}: ${name || (isSpanish ? "No proporcionado" : "Not provided")}`,
-    `${isSpanish ? "Correo" : "Email"}: ${email || (isSpanish ? "No proporcionado" : "Not provided")}`,
-    "",
-    message || "",
+    `${isSpanish ? 'Nombre' : 'Name'}: ${name || (isSpanish ? 'No proporcionado' : 'Not provided')}`,
+    `${isSpanish ? 'Correo' : 'Email'}: ${email || (isSpanish ? 'No proporcionado' : 'Not provided')}`,
+    '',
+    message || ''
   ];
 
-  const mailtoLink = `mailto:carlosortega77@gmail.com?subject=${encodeURIComponent(composedSubject)}&body=${encodeURIComponent(bodyLines.join("\n"))}`;
+  const mailtoLink = `mailto:carlosortega77@gmail.com?subject=${encodeURIComponent(composedSubject)}&body=${encodeURIComponent(bodyLines.join('\n'))}`;
 
   window.location.href = mailtoLink;
 
@@ -150,14 +84,14 @@ function sendEmailFallback(event) {
   }, 300);
 
   alert(isSpanish
-    ? "Los detalles de tu mensaje se prepararon en tu cliente de correo. Revísalos y envíalos para completar el contacto."
-    : "Your message details have been prepared in your email client. Please review and send it to complete your outreach.");
+    ? 'Tu mensaje está listo en tu cliente de correo. Revísalo y envíalo para completar el contacto.'
+    : 'Your message draft is ready in your email client. Review and send it to complete your outreach.');
 }
 
-document.addEventListener("DOMContentLoaded", function() {
-  const contactForm = document.getElementById("contact-form");
+document.addEventListener('DOMContentLoaded', function() {
+  const contactForm = document.getElementById('contact-form');
 
   if (contactForm) {
-    contactForm.addEventListener("submit", sendEmailFallback);
+    contactForm.addEventListener('submit', sendEmailFallback);
   }
 });

--- a/spanish/style.css
+++ b/spanish/style.css
@@ -1,372 +1,599 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap');
-
-body {
-    font-family: 'Montserrat', 'Courier New', monospace;
-    background-color: black;
-    color: white;
-  }
-  
-  .navbar {
-    background-color: black !important;
-    font-family: Arial, Helvetica, sans-serif;
-  }
-  
-  .navbar-brand {
-    font-size: 18px;
-  }
-
-  .navbar-nav {
-    font-size: 14px;
-  }
-
-  .landing {
-    background: linear-gradient(to bottom, black, #333);
-    padding: 80px 0;
-  }
-
-.hero-cta {
-  margin-top: 24px;
+:root {
+  --bg: #0b0d17;
+  --surface: #11182a;
+  --surface-alt: #141d33;
+  --surface-light: #18233a;
+  --border: #1f2a40;
+  --text: #f5f7ff;
+  --muted: #c3cadc;
+  --accent: #5b8def;
+  --accent-soft: rgba(91, 141, 239, 0.18);
+  --success: #41b883;
+  --font-body: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  --font-display: 'Playfair Display', 'Times New Roman', serif;
 }
 
-.hero-cta .btn {
-  font-weight: 600;
-  padding: 12px 28px;
-  border-radius: 50px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding-top: 84px;
+  line-height: 1.7;
+}
+
+a {
+  color: var(--accent);
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  color: #86aef7;
+  text-decoration: none;
+}
+
+.navbar {
+  background-color: rgba(8, 10, 18, 0.95) !important;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  letter-spacing: 0.02em;
+}
+
+.navbar-brand {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+}
+
+.navbar-nav .nav-link {
+  font-weight: 500;
+  color: var(--muted) !important;
+  padding: 0.75rem 1rem;
+}
+
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link:focus {
+  color: var(--text) !important;
+}
+
+main section {
+  padding: 96px 0;
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.section-subtitle,
+.section-intro {
+  max-width: 780px;
+  margin: 0 auto 2.5rem auto;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.hero-layout {
+  row-gap: 40px;
+}
+
+.landing {
+  background: radial-gradient(circle at top left, rgba(91, 141, 239, 0.12), transparent 45%),
+              radial-gradient(circle at bottom right, rgba(65, 184, 131, 0.18), transparent 55%),
+              linear-gradient(140deg, #090b13 0%, #0f1626 60%, #0b0d17 100%);
+  padding: 140px 0 120px;
+}
+
+.hero-eyebrow {
+  display: inline-block;
+  font-size: 0.85rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+.hero-lede {
+  font-size: 1.15rem;
+  color: var(--muted);
+  margin-top: 18px;
 }
 
 .hero-highlights {
   list-style: none;
   padding: 0;
-  margin: 24px auto 0;
-  max-width: 640px;
-  text-align: left;
+  margin: 28px 0 36px;
 }
 
 .hero-highlights li {
-  font-size: 1.05rem;
-  line-height: 1.7;
-  margin-bottom: 14px;
-  padding-left: 28px;
   position: relative;
+  padding-left: 28px;
+  margin-bottom: 14px;
+  font-size: 1.02rem;
 }
 
 .hero-highlights li::before {
-  content: '\2022';
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
   position: absolute;
   left: 0;
-  top: 0;
-  color: #00d1ff;
-  font-size: 1.3rem;
-  line-height: 1.6;
+  top: 10px;
+  box-shadow: 0 0 0 6px var(--accent-soft);
 }
 
-.hero-cta .btn-primary {
-  background-color: #007bff;
-  border-color: #007bff;
+.hero-cta .btn {
+  font-weight: 600;
+  padding: 14px 30px;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.hero-cta .btn-cta {
-  background-color: #00d1ff;
-  border-color: #00d1ff;
-  color: #000;
-  box-shadow: 0 8px 18px rgba(0, 209, 255, 0.3);
+.btn-cta {
+  background: var(--accent);
+  border: 1px solid transparent;
+  color: #05060a;
+  box-shadow: 0 18px 40px rgba(91, 141, 239, 0.28);
 }
 
-.hero-cta .btn-cta:hover {
-  background-color: #1ae0ff;
-  border-color: #1ae0ff;
-  color: #000;
-}
-
-.hero-cta .btn-primary:hover,
-.hero-cta .btn-outline-light:hover {
+.btn-cta:hover,
+.btn-cta:focus {
   transform: translateY(-2px);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+  background: #779ef5;
 }
 
-.hero-cta .btn-outline-light {
-  color: #fff;
-  border-color: #f8f9fa;
+.btn-outline-light:hover,
+.btn-outline-light:focus,
+.btn-primary:hover,
+.btn-primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
 }
 
-.hero-cta .btn-outline-light:hover {
-  background-color: #f8f9fa;
-  color: #000;
-}
-
-@media (max-width: 576px) {
-  .hero-highlights {
-    margin-top: 20px;
-    padding: 0 16px;
-  }
-
-  .hero-highlights li {
-    font-size: 1rem;
-  }
-
-  .hero-cta .btn {
-    width: 100%;
-  }
-}
-
-  .profile-image {
-    width: 360px;
-    height: 360px;
-    border-radius: 50%;
-    margin-top: 26px;
-    margin-bottom: 26px;
-    border: 5px solid white;
-  }
-  
-h2 {
-  font-family: 'Arial', sans-serif; /* Choose a font that suits your preference */
-  font-size: 36px; /* Adjust the size as needed */
-  font-weight: bold;
-}
-
-.about p {
-  font-size: 18px; /* Adjust the size as needed */
-  line-height: 1.6; /* Add line height for better readability */
-  margin-bottom: 26px;
-}
-
-.about-intro {
-  max-width: 720px;
-  margin-left: auto;
-  margin-right: auto;
+.hero-figure {
+  background: rgba(10, 13, 22, 0.8);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 28px;
   text-align: center;
+  margin-bottom: 24px;
 }
 
-.about-highlights {
-  list-style: none;
-  max-width: 880px;
-  margin: 32px auto 0;
-  padding: 0;
-}
-
-.about-highlights li {
-  font-size: 18px;
-  line-height: 1.7;
+.profile-image {
+  width: 100%;
+  max-width: 320px;
+  border-radius: 24px;
+  border: 4px solid rgba(255, 255, 255, 0.12);
   margin-bottom: 18px;
-  padding-left: 28px;
-  position: relative;
 }
 
-.about-highlights li::before {
+.hero-figure figcaption {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero-meta-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.hero-meta-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 20px 22px;
+}
+
+.hero-meta-card h3 {
+  font-size: 1.05rem;
+  margin-bottom: 6px;
+}
+
+.hero-meta-card p {
+  color: var(--muted);
+  margin-bottom: 0;
+}
+
+.about {
+  background: #0c121f;
+}
+
+.about-grid {
+  display: grid;
+  gap: 24px;
+  margin-top: 48px;
+}
+
+.about-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 28px;
+  min-height: 100%;
+}
+
+.about-card h3 {
+  font-size: 1.25rem;
+  margin-bottom: 16px;
+}
+
+.about-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.about-list li {
+  position: relative;
+  padding-left: 22px;
+  margin-bottom: 12px;
+  color: var(--muted);
+}
+
+.about-list li::before {
   content: '\2022';
+  color: var(--accent);
   position: absolute;
   left: 0;
   top: 0;
-  color: #00d1ff;
-  font-size: 1.4rem;
-  line-height: 1.6;
 }
 
-.about,
-  .portfolio,
-  .contact {
-    padding: 100px 0;
-  }
+.capabilities {
+  background: linear-gradient(160deg, #0c121f 0%, #0b0d17 60%, #0c111c 100%);
+}
 
-  #pi {
-    font-family: Times, serif, Arial, Helvetica, sans-serif, serif;
-  }
-
-.contact-summary {
-  background-color: #111;
-  border: 1px solid #222;
-  border-radius: 16px;
+.capability-card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 20px;
   padding: 28px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+}
+
+.capability-card h3 {
+  font-size: 1.25rem;
+  margin-bottom: 12px;
+}
+
+.capability-card p {
+  color: var(--muted);
+  margin-bottom: 16px;
+}
+
+.capability-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.capability-card li {
+  color: var(--muted);
+  position: relative;
+  padding-left: 20px;
+  margin-bottom: 10px;
+}
+
+.capability-card li::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  position: absolute;
+  left: 0;
+  top: 12px;
+}
+
+.experience {
+  background: #0b0f19;
+}
+
+.roadmap-timeline {
+  display: grid;
+  gap: 20px;
+  margin-top: 48px;
+}
+
+.roadmap-item {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 24px 28px 24px 40px;
+}
+
+.roadmap-item::before {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 8px var(--accent-soft);
+  left: 18px;
+  top: 32px;
+}
+
+.roadmap-date {
+  font-size: 0.85rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.roadmap-item h3 {
+  margin-top: 12px;
+  font-size: 1.2rem;
+}
+
+.roadmap-item p {
+  color: var(--muted);
+  margin-bottom: 0;
+}
+
+.certifications {
+  background: #0f1626;
+}
+
+.credential-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  padding: 30px;
   height: 100%;
+}
+
+.credential-card h3 {
+  font-size: 1.2rem;
+  margin-bottom: 18px;
+}
+
+.credential-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.credential-card li {
+  color: var(--muted);
+  margin-bottom: 14px;
+  padding-left: 20px;
+  position: relative;
+}
+
+.credential-card li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--accent);
+}
+
+.portfolio {
+  background: #0c121f;
+}
+
+.custom-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  margin-bottom: 28px;
+}
+
+.custom-card .card-title {
+  font-size: 1.25rem;
+  margin-bottom: 12px;
+}
+
+.custom-card .card-text {
+  color: var(--muted);
+}
+
+.project-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 18px 0;
+}
+
+.badge-tech {
+  background: rgba(91, 141, 239, 0.18);
+  color: var(--accent);
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.project-details {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px;
+}
+
+.project-details li {
+  color: var(--muted);
+  margin-bottom: 10px;
+  padding-left: 20px;
+  position: relative;
+}
+
+.project-details li::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  position: absolute;
+  left: 0;
+  top: 11px;
+}
+
+.project-links {
+  margin-bottom: 14px;
+}
+
+.math-lab {
+  background: #0b0f19;
+}
+
+.math-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 28px;
+  height: 100%;
+}
+
+.math-card p,
+.math-card li {
+  color: var(--muted);
+}
+
+.math-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.math-card li {
+  margin-bottom: 12px;
+  padding-left: 20px;
+  position: relative;
+}
+
+.math-card li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--accent);
+}
+
+.math-lab-footer {
+  color: var(--muted);
+  margin-top: 28px;
+}
+
+.contact {
+  background: linear-gradient(160deg, #0a0f1b 0%, #0b141f 60%, #09101a 100%);
+}
+
+.contact-summary {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
 .contact-actions {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin: 20px 0;
-}
-
-.contact .btn {
-  font-weight: 600;
-  border-radius: 999px;
 }
 
 .contact-btn {
   width: 100%;
-  text-align: center;
 }
 
 .contact-response {
+  color: var(--muted);
   font-size: 0.95rem;
-  line-height: 1.6;
-  margin-bottom: 8px;
-  color: #d0d0d0;
-}
-
-.contact-submit {
-  padding: 12px 28px;
-  width: 100%;
-}
-
-.contact-form .form-group {
-  margin-bottom: 18px;
+  margin: 0;
 }
 
 .contact-form .form-control {
-  background-color: #0a0a0a;
-  border-color: #333;
-  color: #fff;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 14px;
+  padding: 14px 16px;
 }
 
 .contact-form .form-control:focus {
-  box-shadow: 0 0 0 0.2rem rgba(0, 209, 255, 0.25);
-  border-color: #00d1ff;
+  background: var(--surface-light);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 0.25rem rgba(91, 141, 239, 0.2);
 }
 
-@media (min-width: 576px) {
-  .contact-actions {
-    flex-direction: row;
-    flex-wrap: wrap;
+.contact-submit {
+  width: 100%;
+  padding: 14px 28px;
+  border-radius: 14px;
+}
+
+.social-media-container {
+  margin-top: 32px;
+}
+
+.social-media-buttons a {
+  border-radius: 50% !important;
+  width: 46px;
+  height: 46px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 6px;
+  transition: transform 0.2s ease;
+}
+
+.social-media-buttons a:hover,
+.social-media-buttons a:focus {
+  transform: translateY(-2px);
+}
+
+@media (min-width: 768px) {
+  .about-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 991.98px) {
+  body {
+    padding-top: 74px;
   }
 
-  .contact-btn {
-    flex: 1 1 180px;
+  .landing {
+    padding-top: 120px;
+  }
+}
+
+@media (max-width: 767.98px) {
+  main section {
+    padding: 72px 0;
+  }
+
+  .hero-highlights li {
+    font-size: 0.98rem;
+  }
+
+  .hero-meta-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-actions {
+    flex-direction: column;
   }
 }
 
 @media (max-width: 575.98px) {
-  .contact-summary {
-    padding: 24px 20px;
+  .hero-figure {
+    padding: 24px 18px;
   }
-}
 
-.social-media-buttons a.btn.btn-dark,
-.social-media-buttons a.btn.btn-primary,
-.social-media-buttons a.btn.btn-success {
-  border-radius: 50% !important;
-  width: 40px; /* Set a fixed width */
-  height: 40px; /* Set a fixed height */
-  margin-left: 5px;
-  margin-right: 5px;
-}
-
-.social-media-buttons .btn-dark,
-.social-media-buttons a.btn.btn-primary,
-.social-media-buttons .btn-success {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.social-media-buttons .btn-dark i,
-.social-media-buttons a.btn.btn-primary,
-.social-media-buttons .btn-success i {
-  font-size: 24px;
-}
-
-
-.custom-card {
-  background-color: black;
-  color: white;
-  border: 1px solid #333;
-}
-
-.project-badges {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 12px 0 6px;
-}
-
-.badge-tech {
-  background-color: #1ae0ff;
-  color: #000;
-  font-weight: 600;
-  border-radius: 999px;
-  padding: 6px 14px;
-  font-size: 0.75rem;
-  letter-spacing: 0.4px;
-}
-
-.card-body .project-details {
-  list-style: none;
-  padding: 0;
-  margin: 12px 0 16px;
-}
-
-.card-body .project-details li {
-  text-align: left;
-  font-size: 0.95rem;
-  line-height: 1.6;
-  margin-bottom: 8px;
-  position: relative;
-  padding-left: 20px;
-}
-
-.card-body .project-details li::before {
-  content: '\2022';
-  position: absolute;
-  left: 0;
-  top: 0;
-  color: #00d1ff;
-  font-size: 1.1rem;
-  line-height: 1.6;
-}
-
-.project-links {
-  margin-bottom: 12px;
-}
-
-.project-links .btn {
-  margin: 0 4px 8px;
-}
-
-
-.certifications {
-  background-color: #333;
-  color: white;
-  padding: 100px 0;
-}
-
-.certifications h2 {
-  font-size: 36px;
-  font-weight: bold;
-  text-align: center;
-}
-
-.certifications ul {
-  list-style: none;
-  padding: 0;
-}
-
-.certifications li {
-  margin-bottom: 20px;
-  border: 1px solid white;
-  padding: 20px;
-}
-
-.certifications li strong {
-  font-size: 20px;
-  display: block;
-}
-
-.certifications li span {
-  display: block;
-  margin-top: 8px;
-  font-size: 14px;
-}
-
-.certifications li a {
-  color: white;
-  text-decoration: none;
-}
-
-.certifications li a:hover {
-  text-decoration: underline;
+  .profile-image {
+    max-width: 260px;
+  }
 }


### PR DESCRIPTION
## Summary
- Rebuilt the English portfolio with a streamlined hero, refreshed navigation, updated capabilities and experience sections, and richer project narratives to highlight measurable outcomes.
- Mirrored the new structure, messaging, and calls to action in the Spanish portfolio to ensure consistent bilingual positioning.
- Applied a refined visual system with updated typography, card layouts, and interaction styling, and refreshed the shared script for professional PI messaging and bilingual email drafting.

## Testing
- python3 -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68d77585f398832f92f09ae895a82b59