### PR TITLE
i18n: consolidate English locale under /en; remove /english; update links & hreflang

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The production code for highlighted projects lives in dedicated repositories:
 
 ## Repository structure
 
-- `en/`, `es/` — Localized builds of the static site.
+- `en/`, `es/` — Localized builds of the static site. The legacy `english/`
+  directory only hosts a redirect shim that points to `/en/` for backwards
+  compatibility.
 - `assets/` — Shared images, styles, and scripts.
 - `docs/` — Internal documentation, change history, and content governance aids.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Consolidated the English-language entry point under `/en/` and replaced the
   legacy `/english/` folder with a zero-delay redirect to preserve existing
   inbound links.
+- Added hreflang annotations to the `/english/` redirect shell so search bots
+  discover the canonical `/en/` and `/es/` destinations without duplication.
 
 ## 2025-10-15
 

--- a/english/index.html
+++ b/english/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Redirecting to /en/ · Carlos Ortega Portfolio</title>
   <link rel="canonical" href="https://cortega26.github.io/en/">
+  <link rel="alternate" hreflang="en" href="https://cortega26.github.io/en/">
+  <link rel="alternate" hreflang="es" href="https://cortega26.github.io/es/">
   <meta http-equiv="refresh" content="0; url=https://cortega26.github.io/en/">
   <script>
     (function () {


### PR DESCRIPTION
## Summary
- add hreflang annotations to the /english/ redirect shim so crawlers consolidate signals under /en/
- document the redirect-only role of the legacy english/ directory in the README and changelog

## Testing
- Deferred to CI

📊 COMPLIANCE: 8/9 rules met (R3 deferred: static site without automated tests)
🤖 Model: gpt-5-codex-medium
✅ Backwards Compat: compatible
🧪 Tests: none (static HTML)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R3
📝 Commit: fix(seo): add hreflang to english redirect
🔄 Deferred to CI: ruff, black --check, isort --check-only, mypy, pytest -q, bandit -ll, gitleaks, pip-audit

------
https://chatgpt.com/codex/tasks/task_e_68f12b6cb9a0832fb1b92cb64fe50ba2