### PR TITLE
content(hero): keep a single ‘zero fluff’; remove duplicate.

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -133,7 +133,7 @@
             <h1 class="display-4">Tools. Data. Results.</h1>
             <h2 class="hero-subhead">Where tools and math ship value.</h2>
             <p class="hero-name">Carlos Ortega González</p>
-            <p class="hero-lede">I turn messy data into dependable software, combining math, automation, and full-stack engineering craft. Zero fluff.</p>
+            <p class="hero-lede">I turn messy data into dependable software, combining math, automation, and full-stack engineering craft.</p>
             <p class="hero-lockup">Tooltician: part mathematician, part technician—zero fluff.</p>
             <div class="hero-cta d-flex flex-column flex-sm-row align-items-sm-center">
               <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="#project-gdp">See projects</a>

--- a/es/index.html
+++ b/es/index.html
@@ -82,7 +82,7 @@
             <h1 class="display-4">Herramientas. Datos. Resultados.</h1>
             <h2 class="hero-subhead">Donde las herramientas y la matemática entregan valor.</h2>
             <p class="hero-name">Carlos Ortega González</p>
-            <p class="hero-lede">Convierto datos desordenados en software confiable, combinando matemática, automatización e ingeniería full-stack. Cero humo.</p>
+            <p class="hero-lede">Convierto datos desordenados en software confiable, combinando matemática, automatización e ingeniería full-stack.</p>
             <p class="hero-lockup">Tooltician: un poco matemático, un poco técnico—cero humo.</p>
             <div class="hero-cta d-flex flex-column flex-sm-row align-items-sm-center">
               <a class="btn btn-cta btn-lg mb-3 mb-sm-0 mr-sm-3" href="#project-gdp">Ver proyectos</a>


### PR DESCRIPTION
## Summary
- remove the duplicate “Zero fluff” sentence from the English hero lead-in so the brand line carries the message once
- mirror the same adjustment in the Spanish hero to keep the layout balanced across locales

## Testing
- Deferred to CI

![Updated hero copy](browser:/invocations/sqbrxoph/artifacts/artifacts/hero-en.png)

📊 COMPLIANCE: 7/9 rules met (Missing: R3 Testing/coverage not rerun for static copy change; R6 CI gate tooling deferred to CI)
🤖 Model: gpt-5-codex-low
✅ Backwards Compat: compatible
🧪 Tests: none (static content)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R3, R6
📝 Commit: fix(hero): dedupe zero fluff copy
🔄 Deferred to CI: ruff, black --check, isort --check-only, mypy, pytest -q, bandit -ll, gitleaks, pip-audit

------
https://chatgpt.com/codex/tasks/task_e_68f1390e34cc832f83e2ecc324500406