### PR TITLE
docs(readme): clarify site scope; add curated repo links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 This repository hosts the bilingual static portfolio site served at [cortega26.github.io](https://cortega26.github.io/) (English) and [cortega26.github.io/es/](https://cortega26.github.io/es/) (Spanish).
 
-## Where is the code?
+## Scope
 
-The production code for highlighted projects lives in dedicated repositories:
+This repo contains the static site shell (HTML, CSS, assets) only. The production code for featured projects lives in their own repositories:
 
-- [Portfolio Manager](https://github.com/cortega26/Portfolio-Manager) — Maintains the capital-markets analytics toolkit featured in the portfolio.
-- [elrincondeebano](https://github.com/cortega26/elrincondeebano) — Houses the El Rincón de Ébano educational content referenced on the site.
-- [noticiencias](https://github.com/cortega26/noticiencias) — Hosts the Noticiencias news automation workflows cited in the case studies.
+- [Portfolio Manager](https://github.com/cortega26/Portfolio-Manager) — Capital-markets analytics toolkit powering the portfolio case study dashboards.
+- [elrincondeebano](https://github.com/cortega26/elrincondeebano) — Learning resources and curriculum materials showcased under the El Rincón de Ébano initiative.
+- [noticiencias](https://github.com/cortega26/noticiencias) — Automated news aggregation pipelines referenced throughout the Noticiencias write-up.
 
 ## Repository structure
 


### PR DESCRIPTION
## Summary
- add a prominent scope section clarifying this repository only hosts the static portfolio site shell
- highlight three flagship project repositories with concise one-line descriptions

## Testing
- Deferred to CI

📊 COMPLIANCE: 9/9 rules met (None missing)
🤖 Model: gpt-5-codex-low
✅ Backwards Compat: compatible
🧪 Tests: none (docs-only)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: None
📝 Commit: docs(readme): clarify site scope
🔄 Deferred to CI: ruff; black --check; isort --check-only; mypy; pytest -q; bandit -ll; gitleaks; pip-audit

------
https://chatgpt.com/codex/tasks/task_e_68f13e78edf0832fa098ef4ad7d7daea