### PR TITLE
docs(profile): refresh portfolio highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,42 @@
 # Tooltician Portfolio
 
-> Client-focused portfolio — Tooltician. Static site (EN/ES) with case studies, service offerings, and contact channels.
+> Bilingual (EN/ES) portfolio showcasing data products, automation, and open-source highlights.
 
-This repository hosts the bilingual static portfolio site served at [cortega26.github.io](https://cortega26.github.io/) (English) and [cortega26.github.io/es/](https://cortega26.github.io/es/) (Spanish).
+This repository hosts the bilingual static portfolio site served at
+[cortega26.github.io](https://cortega26.github.io/) (English) and
+[cortega26.github.io/es/](https://cortega26.github.io/es/) (Spanish).
+
+## Profile snapshot
+
+- Data product consultant focused on analytics automation, APIs, and KPI storytelling.
+- Builds Python-first tooling: pipelines, scrapers, and reporting systems.
+- Bilingual delivery (ES/EN) across LATAM and U.S.-aligned time zones.
 
 ## Scope
 
 This repo contains the static site shell (HTML, CSS, assets) only. The production code for featured projects lives in their own repositories:
 
-- [Portfolio Manager](https://github.com/cortega26/Portfolio-Manager) — Capital-markets analytics toolkit powering the portfolio case study dashboards.
-- [elrincondeebano](https://github.com/cortega26/elrincondeebano) — Learning resources and curriculum materials showcased under the El Rincón de Ébano initiative.
-- [noticiencias](https://github.com/cortega26/noticiencias) — Automated news aggregation pipelines referenced throughout the Noticiencias write-up.
+- [Portfolio Manager (Server Edition)](https://github.com/cortega26/portfolio-manager-server) — Full-stack portfolio tracker with analytics, security, and observability.
+- [Rutificador](https://github.com/cortega26/rutificador) — Python package for Chilean RUT validation, formatting, and batch processing.
+- [Polla App](https://github.com/cortega26/polla) — Jackpot ingestion pipeline with CLI workflows and Google Sheets updates.
+- [Noticiencias News Collector](https://github.com/cortega26/noticiencias_news_collector) — Modular news ingestion and scoring pipeline with runbooks.
+- [El Rincón de Ébano](https://github.com/cortega26/elrincondeebano) — Offline-first static catalog with automated asset and data pipelines.
+- [PDF Text Analyzer](https://github.com/cortega26/PDF-Text-Analyzer) — PDF extraction + NLP analysis for multilingual documents.
+- [Crypto Price Tracker](https://github.com/cortega26/crypto-price-tracker) — Real-time price alerts, GUI, and reporting.
+- [PoGo Rarity](https://github.com/cortega26/PoGo) — Data aggregation + Streamlit UI for Pokémon GO rarity scoring.
+
+## Highlighted repositories
+
+These repos are the best entry points for recruiters and collaborators:
+
+1. **rutificador** — packaged library + CI + coverage and a clear user-facing API.
+2. **polla** — production-minded scraping pipeline with observability and CLI tooling.
+3. **noticiencias_news_collector** — end-to-end ingestion system with runbooks.
+4. **portfolio-manager-server** — full-stack analytics platform with security controls.
+5. **elrincondeebano** — offline-first static site with automated asset workflows.
+6. **PDF-Text-Analyzer** — focused NLP pipeline with practical, reusable utilities.
+7. **crypto-price-tracker** — real-time alerts + GUI for daily operations.
+8. **PoGo** — data aggregation and Streamlit delivery for gaming analytics.
 
 ## Repository structure
 
@@ -32,4 +58,6 @@ This portfolio is a static site. Serve it with your preferred HTTP server (for e
 
 ## About field follow-up
 
-The GitHub About description must be updated manually to match the README. See [docs/tasks/update-about-field.md](docs/tasks/update-about-field.md) for the exact copy to apply.
+The GitHub About description must be updated manually to match the README.
+See [docs/tasks/update-about-field.md](docs/tasks/update-about-field.md) for
+the exact copy to apply.

--- a/docs/tasks/update-about-field.md
+++ b/docs/tasks/update-about-field.md
@@ -1,6 +1,6 @@
 # Tracking Issue: Update GitHub About Description
 
-- **Proposed copy:** `Client-focused portfolio — Tooltician. Static site (EN/ES) with case studies, service offerings, and contact channels.`
+- **Proposed copy:** `Tooltician portfolio (EN/ES) highlighting data products, automation, and open-source work.`
 - **Action:** After this PR merges, paste the copy above into the repository **About → Description** field in GitHub's UI.
 - **Owner:** Repository maintainer.
 - **Status:** Pending.

--- a/en/index.html
+++ b/en/index.html
@@ -590,6 +590,41 @@ redirect_from:
           </div>
           <div class="col-md-6 mb-4">
             <article class="math-card h-100">
+              <h3>GitHub Highlights</h3>
+              <p>Repos that best represent production-ready data tooling.</p>
+              <ul>
+                <li>
+                  <a href="https://github.com/cortega26/portfolio-manager-server" target="_blank" rel="noopener noreferrer">Portfolio Manager (Server Edition)</a>:
+                  Full-stack analytics, security, and observability.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/noticiencias_news_collector" target="_blank" rel="noopener noreferrer">Noticiencias News Collector</a>:
+                  Modular ingestion + scoring pipeline with runbooks.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/elrincondeebano" target="_blank" rel="noopener noreferrer">El Rincón de Ébano</a>:
+                  Offline-first catalog with automated asset workflows.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/rutificador" target="_blank" rel="noopener noreferrer">Rutificador</a>:
+                  PyPI package for Chilean RUT validation and batch formatting.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/polla" target="_blank" rel="noopener noreferrer">Polla App</a>:
+                  Jackpot ingestion pipeline with CLI and Sheets publishing.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/crypto-price-tracker" target="_blank" rel="noopener noreferrer">Crypto Price Tracker</a>:
+                  Real-time alerts + GUI for market monitoring.
+                </li>
+              </ul>
+              <p class="evidence">Evidence:
+                <a href="https://github.com/cortega26?tab=repositories" target="_blank" rel="noopener noreferrer">GitHub profile</a>
+              </p>
+            </article>
+          </div>
+          <div class="col-md-6 mb-4">
+            <article class="math-card h-100">
               <h3>Quant &amp; Optimization Experiments</h3>
               <p>Validation libraries and experiments focused on quantitative operations.</p>
               <ul>

--- a/es/index.html
+++ b/es/index.html
@@ -479,6 +479,41 @@
           </div>
           <div class="col-md-6 mb-4">
             <article class="math-card h-100">
+              <h3>Destacados en GitHub</h3>
+              <p>Repos que mejor representan trabajo de datos listo para producción.</p>
+              <ul>
+                <li>
+                  <a href="https://github.com/cortega26/portfolio-manager-server" target="_blank" rel="noopener noreferrer">Portfolio Manager (Server Edition)</a>:
+                  Analítica full-stack, seguridad y observabilidad.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/noticiencias_news_collector" target="_blank" rel="noopener noreferrer">Noticiencias News Collector</a>:
+                  Pipeline modular de ingesta + scoring con runbooks.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/elrincondeebano" target="_blank" rel="noopener noreferrer">El Rincón de Ébano</a>:
+                  Catálogo offline-first con flujos automatizados de assets.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/rutificador" target="_blank" rel="noopener noreferrer">Rutificador</a>:
+                  Paquete PyPI para validar y formatear RUTs chilenos.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/polla" target="_blank" rel="noopener noreferrer">Polla App</a>:
+                  Ingesta de pozo con CLI y publicación en Sheets.
+                </li>
+                <li>
+                  <a href="https://github.com/cortega26/crypto-price-tracker" target="_blank" rel="noopener noreferrer">Crypto Price Tracker</a>:
+                  Alertas en tiempo real + GUI para monitoreo.
+                </li>
+              </ul>
+              <p class="evidence">Evidencia:
+                <a href="https://github.com/cortega26?tab=repositories" target="_blank" rel="noopener noreferrer">Perfil en GitHub</a>
+              </p>
+            </article>
+          </div>
+          <div class="col-md-6 mb-4">
+            <article class="math-card h-100">
               <h3>Experimentos cuantitativos</h3>
               <p>Librerías de validación y experimentos enfocados en operaciones cuantitativas.</p>
               <ul>


### PR DESCRIPTION
### Motivation

- Make the portfolio README and site copy clearer and more recruiter-friendly by surfacing a concise profile snapshot and curated repo list.
- Promote production-ready projects so collaborators and hiring contacts can quickly find representative repositories.
- Align the repository "About" guidance with the updated README messaging.

### Description

- Updated `README.md` to add a `Profile snapshot` and a `Highlighted repositories` section with curated links to key repos.
- Updated `docs/tasks/update-about-field.md` to propose new About-field copy: `Tooltician portfolio (EN/ES) highlighting data products, automation, and open-source work.`
- Added GitHub highlights cards to `en/index.html` and `es/index.html` to display featured repositories on the static site.
- Changes were made on branch `docs/profile-refresh` and committed with the message `docs(profile): refresh portfolio highlights`.

### Testing

- Served the static site locally with `python -m http.server 8000` and captured a Playwright screenshot of the updated `/en/` page, which completed successfully.
- No unit or integration tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fe95f7274832f92efe65caf2ff2de)